### PR TITLE
feat: Wave 1 — fix truth gaps, close rivet coverage, add Rocq CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,27 @@ jobs:
           echo "   Output: $OUTPUT_SIZE bytes"
           echo "   Reduction: $REDUCTION%"
 
+  rocq-proofs:
+    name: Rocq Formal Proofs
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.14.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-rocq
+          repository-cache: true
+      - name: Build proofs
+        run: bazel build //proofs/...
+      - name: Test proofs
+        run: bazel test //proofs/... --test_output=errors
+
   differential:
     name: Differential Testing (vs wasm-opt)
     runs-on: ubuntu-latest

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,41 +64,10 @@ LOOM is a WebAssembly optimizer built around three core principles:
                            │
                            ▼
 ┌────────────────────────────────────────────────────────────────┐
-│              12-Phase Optimization Pipeline                     │
+│              10-Phase CLI Optimization Pipeline                 │
 │                                                                 │
 │  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 1: Precompute                                    │  │
-│  │  - Global constant propagation                          │  │
-│  │  - Replace immutable global.get with constants          │  │
-│  └─────────────────────────────────────────────────────────┘  │
-│                           │                                     │
-│                           ▼                                     │
-│  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 2: ISLE Constant Folding (Pre-CSE)              │  │
-│  │  - Convert to ISLE terms                                │  │
-│  │  - Apply pattern matching rules                         │  │
-│  │  - Fold constants: 10 + 20 → 30                        │  │
-│  └─────────────────────────────────────────────────────────┘  │
-│                           │                                     │
-│                           ▼                                     │
-│  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 3: Strength Reduction                            │  │
-│  │  - x * 8 → x << 3  (2-3x speedup)                      │  │
-│  │  - x / 4 → x >> 2  (2-3x speedup)                      │  │
-│  │  - x % 32 → x & 31 (2-3x speedup)                      │  │
-│  └─────────────────────────────────────────────────────────┘  │
-│                           │                                     │
-│                           ▼                                     │
-│  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 4: Common Subexpression Elimination (CSE)       │  │
-│  │  - Hash expressions for duplicate detection             │  │
-│  │  - Cache expensive computations in locals               │  │
-│  │  - Skip caching simple constants                        │  │
-│  └─────────────────────────────────────────────────────────┘  │
-│                           │                                     │
-│                           ▼                                     │
-│  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 5: Function Inlining                             │  │
+│  │  Phase 1: Inline                                        │  │
 │  │  - Build call graph                                      │  │
 │  │  - Inline small, frequently-called functions            │  │
 │  │  - Substitute parameters with arguments                 │  │
@@ -106,50 +75,66 @@ LOOM is a WebAssembly optimizer built around three core principles:
 │                           │                                     │
 │                           ▼                                     │
 │  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 6: ISLE Constant Folding (Post-Inline)          │  │
-│  │  - Fold constants exposed by inlining                   │  │
-│  │  - Cross-function optimization                          │  │
+│  │  Phase 2: Precompute                                    │  │
+│  │  - Global constant propagation                          │  │
+│  │  - Replace immutable global.get with constants          │  │
 │  └─────────────────────────────────────────────────────────┘  │
 │                           │                                     │
 │                           ▼                                     │
 │  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 7: Code Folding                                  │  │
-│  │  - Flatten nested blocks                                │  │
-│  │  - Remove redundant control flow                        │  │
+│  │  Phase 3: Constant Folding                              │  │
+│  │  - Convert to ISLE terms                                │  │
+│  │  - Apply pattern matching rules                         │  │
+│  │  - Fold constants: 10 + 20 → 30                        │  │
 │  └─────────────────────────────────────────────────────────┘  │
 │                           │                                     │
 │                           ▼                                     │
 │  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 8: Loop-Invariant Code Motion (LICM)            │  │
-│  │  - Detect modified locals in loops                      │  │
-│  │  - Hoist constants and unmodified locals                │  │
+│  │  Phase 4: CSE (Common Subexpression Elimination)       │  │
+│  │  - Hash expressions for duplicate detection             │  │
+│  │  - Cache expensive computations in locals               │  │
+│  │  - Skip caching simple constants                        │  │
 │  └─────────────────────────────────────────────────────────┘  │
 │                           │                                     │
 │                           ▼                                     │
 │  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 9: Branch Simplification                         │  │
+│  │  Phase 5: Advanced (Strength Reduction)                 │  │
+│  │  - x * 8 → x << 3  (2-3x speedup)                      │  │
+│  │  - x / 4 → x >> 2  (2-3x speedup)                      │  │
+│  │  - x % 32 → x & 31 (2-3x speedup)                      │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│                           │                                     │
+│                           ▼                                     │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │  Phase 6: Branches                                      │  │
 │  │  - Simplify constant conditions                         │  │
 │  │  - Remove redundant branches                            │  │
 │  └─────────────────────────────────────────────────────────┘  │
 │                           │                                     │
 │                           ▼                                     │
 │  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 10: Dead Code Elimination (DCE)                 │  │
+│  │  Phase 7: DCE (Dead Code Elimination)                  │  │
 │  │  - Remove unreachable code after terminators            │  │
 │  │  - Clean up code following return/br/unreachable        │  │
 │  └─────────────────────────────────────────────────────────┘  │
 │                           │                                     │
 │                           ▼                                     │
 │  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 11: Block Merging                                │  │
+│  │  Phase 8: Merge-blocks                                  │  │
 │  │  - Merge consecutive blocks                             │  │
 │  │  - Reduce control flow overhead                         │  │
 │  └─────────────────────────────────────────────────────────┘  │
 │                           │                                     │
 │                           ▼                                     │
 │  ┌─────────────────────────────────────────────────────────┐  │
-│  │  Phase 12: Vacuum & Simplify Locals                    │  │
+│  │  Phase 9: Vacuum                                        │  │
 │  │  - Remove empty blocks                                   │  │
+│  │  - Final structural cleanup                             │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│                           │                                     │
+│                           ▼                                     │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │  Phase 10: Simplify-locals                              │  │
 │  │  - Eliminate unused local variables                     │  │
 │  │  - Final cleanup pass                                    │  │
 │  └─────────────────────────────────────────────────────────┘  │
@@ -210,7 +195,7 @@ The core optimization library. Contains all optimization passes and the main pip
 
 **Key Modules:**
 - `parse`: WAT/WASM parsing using `wat` and `wasmparser` crates
-- `optimize`: 12-phase optimization pipeline
+- `optimize`: 10-phase optimization pipeline
 - `encode`: WAT/WASM encoding using `wasmprinter` and `wasm-encoder`
 - `verify`: Z3 SMT-based formal verification
 - `component`: WebAssembly Component Model support
@@ -266,9 +251,14 @@ loom optimize <input> [options]
 
 ### Phase Order Rationale
 
-The 12-phase pipeline is carefully ordered to maximize optimization opportunities:
+The 10-phase pipeline is carefully ordered to maximize optimization opportunities:
 
-#### Why Constant Folding Before CSE (Phases 2 & 3)?
+#### Why Inline First (Phase 1)?
+
+Inlining runs first so that subsequent passes (constant folding, CSE,
+strength reduction) can optimise across the now-visible inlined code.
+
+#### Why Constant Folding Before CSE (Phases 3 & 4)?
 
 **Problem**: If CSE runs before constant folding:
 ```wasm
@@ -295,26 +285,7 @@ i32.add
 → i32.const 84  # Folded before CSE sees it
 ```
 
-#### Why ISLE Twice (Phases 2 & 6)?
-
-**Phase 2 (Pre-CSE)**: Fold obvious constants
-**Phase 6 (Post-Inline)**: Fold constants exposed by inlining
-
-Example:
-```wasm
-(func $add_ten (param $x i32) (result i32)
-  local.get $x
-  i32.const 10
-  i32.add
-)
-
-(func $main (result i32)
-  i32.const 5
-  call $add_ten  # After inlining: 5 + 10, foldable!
-)
-```
-
-#### Why Strength Reduction After Constant Folding?
+#### Why Strength Reduction After Constant Folding (Phase 5)?
 
 Constants might create optimization opportunities:
 ```wasm

--- a/safety/requirements/design-decisions.yaml
+++ b/safety/requirements/design-decisions.yaml
@@ -167,3 +167,116 @@ artifacts:
     links:
       - type: satisfies
         target: REQ-11
+
+  - id: DD-8
+    type: design-decision
+    title: HashMap usage policy
+    status: approved
+    description: >
+      Use BTreeMap for iteration-order-sensitive maps (CSE caching,
+      register coloring), HashMap only for pure lookups.
+    fields:
+      rationale: >
+        REQ-14 requires deterministic output. HashMap iteration order
+        is non-deterministic across runs and platforms. BTreeMap provides
+        sorted, deterministic iteration at minimal performance cost for
+        the map sizes involved in optimization passes.
+      alternatives: >
+        Alternative 1: HashMap everywhere with post-hoc sorting (rejected:
+        easy to forget sorting step, fragile). Alternative 2: IndexMap
+        (rejected: additional dependency, BTreeMap is in std).
+    links:
+      - type: satisfies
+        target: REQ-14
+
+  - id: DD-9
+    type: design-decision
+    title: Greedy graph coloring for local coalescing
+    status: approved
+    description: >
+      Use interference graph with greedy coloring (sorted by degree)
+      for local variable allocation.
+    fields:
+      rationale: >
+        O(V+E) complexity, deterministic with sorted input. Greedy
+        coloring on a sorted vertex list produces consistent results
+        across runs. The interference graph accurately models which
+        locals have overlapping live ranges and cannot share a slot.
+      alternatives: >
+        Alternative 1: Linear scan allocation (rejected: less effective
+        at coalescing non-adjacent live ranges). Alternative 2: Optimal
+        graph coloring via ILP (rejected: NP-hard, overkill for typical
+        local counts).
+    links:
+      - type: satisfies
+        target: REQ-9
+
+  - id: DD-10
+    type: design-decision
+    title: Post-optimization stack validation
+    status: approved
+    description: >
+      Run stack validation after all optimization passes as
+      defense-in-depth. Rejects functions that fail validation.
+    fields:
+      rationale: >
+        Catches optimization bugs before encoding. Even if individual
+        passes are proven correct, their composition may introduce
+        stack discipline violations due to implementation bugs. Running
+        validation after the full pipeline provides a final safety net
+        per REQ-13.
+      alternatives: >
+        Alternative: Validate only at encoding time via wasm-tools
+        (rejected: late detection gives poor error messages and does not
+        distinguish which pass caused the issue).
+    links:
+      - type: satisfies
+        target: REQ-13
+
+  - id: DD-11
+    type: design-decision
+    title: Conservative LICM
+    status: approved
+    description: >
+      Never hoist instructions past call instructions (calls may have
+      side effects).
+    fields:
+      rationale: >
+        REQ-5 mandates conservative-over-fast. Calls may modify globals,
+        memory, or trap, so hoisting past them could change observable
+        behavior. By treating all calls as optimization barriers, LICM
+        remains sound without requiring interprocedural analysis.
+      alternatives: >
+        Alternative: Interprocedural purity analysis to identify safe-to-hoist
+        calls (rejected: complex, fragile, and violates conservative principle
+        until proven correct).
+    links:
+      - type: satisfies
+        target: REQ-5
+
+  - id: DD-12
+    type: design-decision
+    title: Two-tier verification
+    status: approved
+    description: >
+      Z3 SMT for runtime translation validation plus Rocq mechanized
+      proofs for foundational correctness.
+    fields:
+      rationale: >
+        Z3 catches optimization bugs per-run by checking that the
+        optimized function is semantically equivalent to the original.
+        Rocq proves invariants for all inputs, providing foundational
+        assurance that the rewrite rules are correct. The two tiers are
+        complementary: Z3 catches implementation bugs, Rocq proves the
+        rules themselves.
+      alternatives: >
+        Alternative 1: Z3 only (rejected: cannot prove universal properties,
+        only checks concrete runs). Alternative 2: Rocq only (rejected:
+        does not catch implementation bugs in the optimizer code).
+    links:
+      - type: satisfies
+        target: REQ-1
+      - type: satisfies
+        target: REQ-6
+      - type: satisfies
+        target: REQ-7

--- a/safety/requirements/features.yaml
+++ b/safety/requirements/features.yaml
@@ -219,3 +219,45 @@ artifacts:
     links:
       - type: satisfies
         target: REQ-18
+
+  - id: FEAT-15
+    type: feature
+    title: Redundant set elimination (RSE)
+    status: approved
+    description: >
+      Removes redundant local.set instructions when a subsequent set
+      overwrites the same local without an intervening get. Reduces
+      code size and eliminates unnecessary stack operations.
+    fields:
+      phase: phase-1
+    links:
+      - type: satisfies
+        target: REQ-9
+
+  - id: FEAT-16
+    type: feature
+    title: Interference graph register allocation
+    status: approved
+    description: >
+      Greedy graph coloring to coalesce local variables, reducing local
+      count. Builds an interference graph of live ranges and assigns
+      locals using sorted-by-degree greedy coloring.
+    fields:
+      phase: phase-1
+    links:
+      - type: satisfies
+        target: REQ-9
+
+  - id: FEAT-17
+    type: feature
+    title: Precompute pass
+    status: approved
+    description: >
+      Propagates immutable global constants into function bodies,
+      replacing global.get of immutable globals with their constant
+      values to enable further constant folding.
+    fields:
+      phase: phase-1
+    links:
+      - type: satisfies
+        target: REQ-9

--- a/safety/requirements/requirements.yaml
+++ b/safety/requirements/requirements.yaml
@@ -135,14 +135,20 @@ artifacts:
 
   - id: REQ-10
     type: requirement
-    title: 12-phase optimization pipeline
+    title: 10-phase CLI optimization pipeline
     status: approved
     description: >
-      The optimizer must implement the following phases in order:
-      1. Precompute, 2. ISLE constant folding (pre-CSE), 3. Strength
-      reduction, 4. CSE, 5. Function inlining, 6. ISLE constant folding
-      (post-inline), 7. Code folding, 8. LICM, 9. Branch simplification,
-      10. DCE, 11. Block merging, 12. Vacuum and simplify locals.
+      The CLI optimizer (loom-cli/src/main.rs) must implement the following
+      phases in order: 1. Inline (function inlining), 2. Precompute (global
+      constant propagation), 3. Constant folding (ISLE pattern-match
+      folding), 4. CSE (common subexpression elimination), 5. Advanced
+      (strength reduction, bitwise tricks), 6. Branches (branch
+      simplification), 7. DCE (dead code elimination), 8. Merge-blocks
+      (block merging), 9. Vacuum (empty block removal), 10. Simplify-locals
+      (unused local elimination). The library API entry point
+      optimize_module() in loom-core/src/lib.rs provides a subset of these
+      passes for programmatic use; the CLI pipeline is the canonical
+      ordering.
     fields:
       priority: must
       category: functional

--- a/safety/stpa/ucas.yaml
+++ b/safety/stpa/ucas.yaml
@@ -7,317 +7,378 @@
 #   2. Providing the control action leads to a hazard
 #   3. Providing too early, too late, or in the wrong order
 #   4. Control action stopped too soon or applied too long
+#
+# Flat format (workaround for rivet#129: grouped UCA format not parsed)
 
-# ============================================================================
-# Parser UCAs
-# ============================================================================
-parser-ucas:
-  control-action: "Parse WebAssembly operators into IR instructions"
-  controller: CTRL-1
+ucas:
+  # ============================================================================
+  # Parser UCAs (CTRL-1)
+  # ============================================================================
+  - id: UCA-1
+    title: Parser maps operator to wrong Instruction variant
+    uca-type: providing
+    controller: CTRL-1
+    control-action: "Parse WebAssembly operators into IR instructions"
+    description: >
+      Parser maps operator to wrong Instruction variant or with wrong
+      field values (memory index, alignment, signedness)
+    context: Parser encounters a wasmparser Operator and translates it
+    hazards: [H-11]
+    rationale: >
+      Wrong IR representation means all subsequent optimizations operate
+      on a program that does not match the input.
 
-  providing:
-    - id: UCA-1
-      description: >
-        Parser maps operator to wrong Instruction variant or with wrong
-        field values (memory index, alignment, signedness)
-      context: Parser encounters a wasmparser Operator and translates it
-      hazards: [H-11]
-      rationale: >
-        Wrong IR representation means all subsequent optimizations operate
-        on a program that does not match the input.
+  - id: UCA-2
+    title: Parser silently drops unsupported operator
+    uca-type: not-providing
+    controller: CTRL-1
+    control-action: "Parse WebAssembly operators into IR instructions"
+    description: >
+      Parser silently drops unsupported operator without recording it
+      as Unknown and without flagging the function for skip
+    context: Parser encounters an operator it does not recognize
+    hazards: [H-11]
+    rationale: >
+      The dropped instruction is absent from the IR. Optimization and
+      encoding proceed without it, producing output that is missing
+      instructions from the original program.
 
-    - id: UCA-3
-      description: >
-        Parser drops memory index on load/store in multi-memory module,
-        defaulting to memory 0
-      context: Module uses multiple memories
-      hazards: [H-11, H-2]
-      rationale: >
-        Subsequent optimization treats all memory accesses as targeting
-        memory 0, enabling invalid CSE or code motion across memories.
+  - id: UCA-3
+    title: Parser drops memory index on load/store in multi-memory module
+    uca-type: providing
+    controller: CTRL-1
+    control-action: "Parse WebAssembly operators into IR instructions"
+    description: >
+      Parser drops memory index on load/store in multi-memory module,
+      defaulting to memory 0
+    context: Module uses multiple memories
+    hazards: [H-11, H-2]
+    rationale: >
+      Subsequent optimization treats all memory accesses as targeting
+      memory 0, enabling invalid CSE or code motion across memories.
 
-  not-providing:
-    - id: UCA-2
-      description: >
-        Parser silently drops unsupported operator without recording it
-        as Unknown and without flagging the function for skip
-      context: Parser encounters an operator it does not recognize
-      hazards: [H-11]
-      rationale: >
-        The dropped instruction is absent from the IR. Optimization and
-        encoding proceed without it, producing output that is missing
-        instructions from the original program.
+  # ============================================================================
+  # ISLE term rewriter UCAs (CTRL-2)
+  # ============================================================================
+  - id: UCA-4
+    title: ISLE applies rewrite rule invalid for edge-case inputs
+    uca-type: providing
+    controller: CTRL-2
+    control-action: "Apply ISLE rewrite rules to optimize terms"
+    description: >
+      ISLE applies rewrite rule that is not semantically valid for
+      edge-case inputs (zero divisor, NaN, overflow, MIN_INT, negative
+      values)
+    context: A rewrite rule fires on a term whose operands include edge-case values
+    hazards: [H-1]
+    rationale: >
+      The optimized term produces a different result than the original
+      for those specific input values. The bug may not manifest in
+      testing if the edge case is not exercised.
 
-# ============================================================================
-# ISLE term rewriter UCAs
-# ============================================================================
-isle-rewriter-ucas:
-  control-action: "Apply ISLE rewrite rules to optimize terms"
-  controller: CTRL-2
+  - id: UCA-5
+    title: ISLE folds trapping operation to constant, suppressing the trap
+    uca-type: providing
+    controller: CTRL-2
+    control-action: "Apply ISLE rewrite rules to optimize terms"
+    description: >
+      ISLE folds trapping operation to constant, suppressing the trap
+      (div by zero, out-of-range truncation, NaN truncation)
+    context: A constant-folding rule evaluates an operation at compile time that would trap at runtime
+    hazards: [H-1]
+    rationale: >
+      The original program traps; the optimized program silently produces
+      a value. This changes observable behavior.
 
-  providing:
-    - id: UCA-4
-      description: >
-        ISLE applies rewrite rule that is not semantically valid for
-        edge-case inputs (zero divisor, NaN, overflow, MIN_INT, negative
-        values)
-      context: A rewrite rule fires on a term whose operands include edge-case values
-      hazards: [H-1]
-      rationale: >
-        The optimized term produces a different result than the original
-        for those specific input values. The bug may not manifest in
-        testing if the edge case is not exercised.
+  - id: UCA-6
+    title: instructions_to_terms() drops semantically relevant field
+    uca-type: not-providing
+    controller: CTRL-2
+    control-action: "Apply ISLE rewrite rules to optimize terms"
+    description: >
+      instructions_to_terms() drops a semantically relevant field
+      (memory index, alignment, signedness) during conversion
+    context: An instruction with multiple fields is converted to a term
+    hazards: [H-2]
+    rationale: >
+      The term does not fully represent the instruction. Optimization
+      proceeds on an incomplete model.
 
-    - id: UCA-5
-      description: >
-        ISLE folds trapping operation to constant, suppressing the trap
-        (div by zero, out-of-range truncation, NaN truncation)
-      context: A constant-folding rule evaluates an operation at compile time that would trap at runtime
-      hazards: [H-1]
-      rationale: >
-        The original program traps; the optimized program silently produces
-        a value. This changes observable behavior.
+  - id: UCA-7
+    title: Term-to-instruction conversion emits wrong opcode or immediate
+    uca-type: providing
+    controller: CTRL-2
+    control-action: "Apply ISLE rewrite rules to optimize terms"
+    description: >
+      Term-to-instruction conversion emits wrong opcode or wrong
+      immediate value for an optimized term
+    context: terms_to_instructions() converts an optimized term back to instructions
+    hazards: [H-3]
+    rationale: >
+      The encoded instruction has different behavior than the term
+      it was supposed to represent.
 
-    - id: UCA-7
-      description: >
-        Term-to-instruction conversion emits wrong opcode or wrong
-        immediate value for an optimized term
-      context: terms_to_instructions() converts an optimized term back to instructions
-      hazards: [H-3]
-      rationale: >
-        The encoded instruction has different behavior than the term
-        it was supposed to represent.
+  - id: UCA-8
+    title: Strength reduction applied to signed operation as if unsigned
+    uca-type: providing
+    controller: CTRL-2
+    control-action: "Apply ISLE rewrite rules to optimize terms"
+    description: >
+      Strength reduction applied to signed operation as if unsigned
+      (e.g., i32.div_s replaced with shift without negative-number
+      adjustment)
+    context: Strength reduction replaces division or modulo with shift or AND
+    hazards: [H-14]
+    rationale: >
+      Signed division rounds toward zero; arithmetic right shift rounds
+      toward negative infinity. For negative dividends, the results differ.
 
-    - id: UCA-8
-      description: >
-        Strength reduction applied to signed operation as if unsigned
-        (e.g., i32.div_s replaced with shift without negative-number
-        adjustment)
-      context: Strength reduction replaces division or modulo with shift or AND
-      hazards: [H-14]
-      rationale: >
-        Signed division rounds toward zero; arithmetic right shift rounds
-        toward negative infinity. For negative dividends, the results differ.
+  # ============================================================================
+  # Pipeline orchestrator UCAs (CTRL-3)
+  # ============================================================================
+  - id: UCA-9
+    title: Pipeline fails to skip function with unsupported instructions
+    uca-type: not-providing
+    controller: CTRL-3
+    control-action: "Sequence optimization phases and transform IR"
+    description: >
+      Pipeline fails to skip function containing instructions that
+      LOOM cannot correctly handle
+    context: has_unsupported_isle_instructions does not detect all unsupported instructions
+    hazards: [H-1, H-2]
+    rationale: >
+      The function is optimized despite containing instructions the
+      optimizer does not understand, leading to unpredictable output.
 
-  not-providing:
-    - id: UCA-6
-      description: >
-        instructions_to_terms() drops a semantically relevant field
-        (memory index, alignment, signedness) during conversion
-      context: An instruction with multiple fields is converted to a term
-      hazards: [H-2]
-      rationale: >
-        The term does not fully represent the instruction. Optimization
-        proceeds on an incomplete model.
+  - id: UCA-10
+    title: DCE removes live code after conditional branch
+    uca-type: providing
+    controller: CTRL-3
+    control-action: "Sequence optimization phases and transform IR"
+    description: >
+      DCE removes instruction after conditional branch (br_if),
+      treating it as an unconditional terminator
+    context: Code follows a br_if instruction whose fall-through path is live
+    hazards: [H-5]
+    rationale: >
+      Live code is removed. The function's behavior changes for inputs
+      where the branch is not taken.
 
-# ============================================================================
-# Pipeline orchestrator UCAs
-# ============================================================================
-pipeline-ucas:
-  control-action: "Sequence optimization phases and transform IR"
-  controller: CTRL-3
+  - id: UCA-11
+    title: CSE caches expression with intervening memory store
+    uca-type: providing
+    controller: CTRL-3
+    control-action: "Sequence optimization phases and transform IR"
+    description: >
+      CSE caches expression involving memory load with intervening
+      memory store that may modify the loaded address
+    context: Two identical memory load expressions with a store between them
+    hazards: [H-6]
+    rationale: >
+      The second load should return the new value but instead returns
+      the cached (stale) value.
 
-  providing:
-    - id: UCA-10
-      description: >
-        DCE removes instruction after conditional branch (br_if),
-        treating it as an unconditional terminator
-      context: Code follows a br_if instruction whose fall-through path is live
-      hazards: [H-5]
-      rationale: >
-        Live code is removed. The function's behavior changes for inputs
-        where the branch is not taken.
+  - id: UCA-12
+    title: Function inlining does not remap callee local indices
+    uca-type: not-providing
+    controller: CTRL-3
+    control-action: "Sequence optimization phases and transform IR"
+    description: >
+      Function inlining does not remap callee local indices to
+      non-conflicting indices in the caller
+    context: Inliner substitutes callee body at call site
+    hazards: [H-7]
+    rationale: >
+      The inlined code reads/writes the caller's locals instead of its
+      own, corrupting caller state.
 
-    - id: UCA-11
-      description: >
-        CSE caches expression involving memory load with intervening
-        memory store that may modify the loaded address
-      context: Two identical memory load expressions with a store between them
-      hazards: [H-6]
-      rationale: >
-        The second load should return the new value but instead returns
-        the cached (stale) value.
+  - id: UCA-13
+    title: Inlining applied to recursive function without depth bound
+    uca-type: stopped-too-soon
+    controller: CTRL-3
+    control-action: "Sequence optimization phases and transform IR"
+    description: >
+      Inlining applied to recursive function without depth bound,
+      causing infinite expansion
+    context: A function directly or indirectly calls itself
+    hazards: [H-7]
+    rationale: >
+      Infinite expansion causes the optimizer to hang or exhaust memory.
 
-    - id: UCA-14
-      description: >
-        Branch simplification treats mutable local as constant when
-        the local is modified inside the block
-      context: A local set to constant before a block, modified inside the block
-      hazards: [H-8]
-      rationale: >
-        The branch condition depends on the modified value, not the initial
-        constant. A live branch is removed.
+  - id: UCA-14
+    title: Branch simplification treats mutable local as constant
+    uca-type: providing
+    controller: CTRL-3
+    control-action: "Sequence optimization phases and transform IR"
+    description: >
+      Branch simplification treats mutable local as constant when
+      the local is modified inside the block
+    context: A local set to constant before a block, modified inside the block
+    hazards: [H-8]
+    rationale: >
+      The branch condition depends on the modified value, not the initial
+      constant. A live branch is removed.
 
-    - id: UCA-15
-      description: >
-        LICM hoists instruction that depends on a local modified by
-        a call instruction inside the loop
-      context: Loop body contains calls and LICM hoists an instruction past them
-      hazards: [H-9]
-      rationale: >
-        The hoisted instruction uses a value from before the loop instead
-        of the updated value from each iteration.
+  - id: UCA-15
+    title: LICM hoists instruction dependent on call-modified local
+    uca-type: providing
+    controller: CTRL-3
+    control-action: "Sequence optimization phases and transform IR"
+    description: >
+      LICM hoists instruction that depends on a local modified by
+      a call instruction inside the loop
+    context: Loop body contains calls and LICM hoists an instruction past them
+    hazards: [H-9]
+    rationale: >
+      The hoisted instruction uses a value from before the loop instead
+      of the updated value from each iteration.
 
-    - id: UCA-16
-      description: >
-        Block merging changes branch target depth without adjusting
-        contained br/br_if/br_table instructions
-      context: Block merging eliminates a block layer
-      hazards: [H-15]
-      rationale: >
-        Branches now target a different block than intended, changing
-        control flow.
+  - id: UCA-16
+    title: Block merging changes branch target depth without adjustment
+    uca-type: providing
+    controller: CTRL-3
+    control-action: "Sequence optimization phases and transform IR"
+    description: >
+      Block merging changes branch target depth without adjusting
+      contained br/br_if/br_table instructions
+    context: Block merging eliminates a block layer
+    hazards: [H-15]
+    rationale: >
+      Branches now target a different block than intended, changing
+      control flow.
 
-    - id: UCA-17
-      description: >
-        Precompute replaces global.get for a mutable global with its
-        initial value
-      context: Global is declared as mutable, may be modified by other functions
-      hazards: [H-16]
-      rationale: >
-        The constant value is wrong after any mutation of the global.
+  - id: UCA-17
+    title: Precompute replaces mutable global.get with initial value
+    uca-type: providing
+    controller: CTRL-3
+    control-action: "Sequence optimization phases and transform IR"
+    description: >
+      Precompute replaces global.get for a mutable global with its
+      initial value
+    context: Global is declared as mutable, may be modified by other functions
+    hazards: [H-16]
+    rationale: >
+      The constant value is wrong after any mutation of the global.
 
-  not-providing:
-    - id: UCA-9
-      description: >
-        Pipeline fails to skip function containing instructions that
-        LOOM cannot correctly handle
-      context: has_unsupported_isle_instructions does not detect all unsupported instructions
-      hazards: [H-1, H-2]
-      rationale: >
-        The function is optimized despite containing instructions the
-        optimizer does not understand, leading to unpredictable output.
+  # ============================================================================
+  # Stack validator UCAs (CTRL-4)
+  # ============================================================================
+  - id: UCA-18
+    title: Stack validator uses wrong signature for call_indirect
+    uca-type: providing
+    controller: CTRL-4
+    control-action: "Validate WebAssembly stack discipline"
+    description: >
+      Stack validator uses wrong signature for call_indirect due to
+      missing or incorrect type_signatures lookup
+    context: call_indirect references a type index
+    hazards: [H-4]
+    rationale: >
+      The validator approves an instruction sequence with wrong stack
+      effect, producing a binary that fails at runtime.
 
-    - id: UCA-12
-      description: >
-        Function inlining does not remap callee local indices to
-        non-conflicting indices in the caller
-      context: Inliner substitutes callee body at call site
-      hazards: [H-7]
-      rationale: >
-        The inlined code reads/writes the caller's locals instead of its
-        own, corrupting caller state.
+  - id: UCA-19
+    title: Stack validator rejects valid unreachable code
+    uca-type: not-providing
+    controller: CTRL-4
+    control-action: "Validate WebAssembly stack discipline"
+    description: >
+      Stack validator does not enter polymorphic mode after
+      unconditional branch, rejecting valid unreachable code
+    context: Code follows an unconditional terminator inside a block
+    hazards: [H-4]
+    rationale: >
+      Valid functions are rejected, preventing optimization.
 
-  stopped-too-soon:
-    - id: UCA-13
-      description: >
-        Inlining applied to recursive function without depth bound,
-        causing infinite expansion
-      context: A function directly or indirectly calls itself
-      hazards: [H-7]
-      rationale: >
-        Infinite expansion causes the optimizer to hang or exhaust memory.
+  # ============================================================================
+  # Z3 verifier UCAs (CTRL-5)
+  # ============================================================================
+  - id: UCA-20
+    title: Z3 encoding uses wrong bit-width or signed/unsigned variant
+    uca-type: providing
+    controller: CTRL-5
+    control-action: "Verify semantic equivalence via SMT"
+    description: >
+      Z3 encoding uses wrong bit-width or wrong signed/unsigned variant
+      for a bitvector operation
+    context: SMT encoding of i32 or i64 arithmetic operations
+    hazards: [H-12]
+    rationale: >
+      Z3 verifies equivalence of the wrong formulas. A bug in the
+      optimizer is not detected because the verifier is also wrong.
 
-# ============================================================================
-# Stack validator UCAs
-# ============================================================================
-stack-validator-ucas:
-  control-action: "Validate WebAssembly stack discipline"
-  controller: CTRL-4
+  - id: UCA-21
+    title: Z3 encoding omits trap condition for trapping operations
+    uca-type: not-providing
+    controller: CTRL-5
+    control-action: "Verify semantic equivalence via SMT"
+    description: >
+      Z3 encoding omits trap condition for trapping operations
+      (division by zero, out-of-range truncation)
+    context: SMT encoding of division, remainder, or truncation operations
+    hazards: [H-12]
+    rationale: >
+      A trap-suppression bug is not detected by verification.
 
-  providing:
-    - id: UCA-18
-      description: >
-        Stack validator uses wrong signature for call_indirect due to
-        missing or incorrect type_signatures lookup
-      context: call_indirect references a type index
-      hazards: [H-4]
-      rationale: >
-        The validator approves an instruction sequence with wrong stack
-        effect, producing a binary that fails at runtime.
+  # ============================================================================
+  # Binary encoder UCAs (CTRL-6)
+  # ============================================================================
+  - id: UCA-22
+    title: Encoder emits wrong LEB128 encoding for large values
+    uca-type: providing
+    controller: CTRL-6
+    control-action: "Encode Module IR to WebAssembly binary"
+    description: >
+      Encoder emits wrong LEB128 encoding for large values (function
+      indices, type indices, memory offsets)
+    context: A value exceeds the range of a single LEB128 byte
+    hazards: [H-10]
+    rationale: >
+      The binary is malformed. Runtimes may reject it or misinterpret
+      the value.
 
-  not-providing:
-    - id: UCA-19
-      description: >
-        Stack validator does not enter polymorphic mode after
-        unconditional branch, rejecting valid unreachable code
-      context: Code follows an unconditional terminator inside a block
-      hazards: [H-4]
-      rationale: >
-        Valid functions are rejected, preventing optimization.
+  - id: UCA-23
+    title: Encoder computes wrong function body byte length
+    uca-type: providing
+    controller: CTRL-6
+    control-action: "Encode Module IR to WebAssembly binary"
+    description: >
+      Encoder computes wrong function body byte length, causing
+      section misalignment
+    context: Function body has variable-length LEB128 immediates
+    hazards: [H-10]
+    rationale: >
+      The length prefix does not match the body, causing the binary
+      parser to misalign all subsequent sections.
 
-# ============================================================================
-# Z3 verifier UCAs
-# ============================================================================
-z3-verifier-ucas:
-  control-action: "Verify semantic equivalence via SMT"
-  controller: CTRL-5
+  # ============================================================================
+  # Component model optimizer UCAs (CTRL-7)
+  # ============================================================================
+  - id: UCA-24
+    title: Same-memory adapter collapse skips data transformation
+    uca-type: providing
+    controller: CTRL-7
+    control-action: "Optimize Component Model adapter functions"
+    description: >
+      Same-memory adapter collapse skips necessary data transformation
+      (string encoding, list element reinterpretation)
+    context: >
+      Two adapters share the same linear memory but perform encoding
+      conversion
+    hazards: [H-13]
+    rationale: >
+      The callee receives data in the wrong encoding.
 
-  providing:
-    - id: UCA-20
-      description: >
-        Z3 encoding uses wrong bit-width or wrong signed/unsigned variant
-        for a bitvector operation
-      context: SMT encoding of i32 or i64 arithmetic operations
-      hazards: [H-12]
-      rationale: >
-        Z3 verifies equivalence of the wrong formulas. A bug in the
-        optimizer is not detected because the verifier is also wrong.
-
-  not-providing:
-    - id: UCA-21
-      description: >
-        Z3 encoding omits trap condition for trapping operations
-        (division by zero, out-of-range truncation)
-      context: SMT encoding of division, remainder, or truncation operations
-      hazards: [H-12]
-      rationale: >
-        A trap-suppression bug is not detected by verification.
-
-# ============================================================================
-# Binary encoder UCAs
-# ============================================================================
-encoder-ucas:
-  control-action: "Encode Module IR to WebAssembly binary"
-  controller: CTRL-6
-
-  providing:
-    - id: UCA-22
-      description: >
-        Encoder emits wrong LEB128 encoding for large values (function
-        indices, type indices, memory offsets)
-      context: A value exceeds the range of a single LEB128 byte
-      hazards: [H-10]
-      rationale: >
-        The binary is malformed. Runtimes may reject it or misinterpret
-        the value.
-
-    - id: UCA-23
-      description: >
-        Encoder computes wrong function body byte length, causing
-        section misalignment
-      context: Function body has variable-length LEB128 immediates
-      hazards: [H-10]
-      rationale: >
-        The length prefix does not match the body, causing the binary
-        parser to misalign all subsequent sections.
-
-# ============================================================================
-# Component model optimizer UCAs
-# ============================================================================
-component-optimizer-ucas:
-  control-action: "Optimize Component Model adapter functions"
-  controller: CTRL-7
-
-  providing:
-    - id: UCA-24
-      description: >
-        Same-memory adapter collapse skips necessary data transformation
-        (string encoding, list element reinterpretation)
-      context: >
-        Two adapters share the same linear memory but perform encoding
-        conversion
-      hazards: [H-13]
-      rationale: >
-        The callee receives data in the wrong encoding.
-
-  too-early-too-late:
-    - id: UCA-25
-      description: >
-        Fused module optimization reorders adapter execution, changing
-        observable state (memory writes, resource handle allocation)
-      context: Multiple adapters with shared state are optimized together
-      hazards: [H-13]
-      rationale: >
-        The component's behavior changes due to reordering even though
-        each individual adapter is correct in isolation.
+  - id: UCA-25
+    title: Fused module optimization reorders adapter execution
+    uca-type: too-early-too-late
+    controller: CTRL-7
+    control-action: "Optimize Component Model adapter functions"
+    description: >
+      Fused module optimization reorders adapter execution, changing
+      observable state (memory writes, resource handle allocation)
+    context: Multiple adapters with shared state are optimized together
+    hazards: [H-13]
+    rationale: >
+      The component's behavior changes due to reordering even though
+      each individual adapter is correct in isolation.


### PR DESCRIPTION
## Summary

- **UCA YAML restructured** (workaround rivet#129): flat `ucas:` format, all 25 UCAs now parsed (was 3), 33 broken links resolved. `rivet validate` goes from FAIL (55 errors) to **PASS (0 errors)**.
- **Pipeline ordering docs** (REQ-10): Updated REQ-10 and architecture.md to match actual CLI 10-phase order.
- **New rivet artifacts**: FEAT-15/16/17 and DD-8/9/10/11/12 for code-verified capabilities.
- **Rocq CI** (#45): Added rocq-proofs job with Nix + Bazel (continue-on-error initially).

### Rivet metrics

| Metric | Before | After |
|--------|--------|-------|
| Artifacts | 144 | **174** |
| Validation | FAIL (55 errors) | **PASS (0 errors)** |
| UCAs parsed | 3/25 | **25/25** |
| Broken links | 33 | **0** |
| Features | 14 | **17** |
| Design decisions | 7 | **12** |
| STPA chain coverage | 8.3% (CC→UCA) | **100%** |

## Test plan

- [x] `rivet validate` — PASS (0 errors, 47 warnings)
- [x] `rivet stats` — 174 artifacts, 0 broken links
- [x] All pre-commit hooks pass
- [ ] CI checks (Rocq job expected to be advisory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)