### PR TITLE
release/v0.4.0 PR-C: visible verifier skip diagnostics + br_table hoist regression test

### DIFF
--- a/loom-core/src/verify.rs
+++ b/loom-core/src/verify.rs
@@ -1592,11 +1592,37 @@ pub fn verify_function_equivalence(
     }
 
     // Skip verification for functions containing imprecisely-modeled instructions
-    // (memory ops, unknown ops) - these would produce false counterexamples
+    // (float load/store, unknown ops) — these would produce false counterexamples.
+    //
+    // KNOWN LIMITATION: returning Ok(true) here means callers' verify_or_revert
+    // accept the transform without proof. PR-B added pass-level hoist guards
+    // (LICM, CSE, code_folding, coalesce_locals) that skip BrIf/BrTable
+    // functions entirely, so the silent skip cannot mask a hoisting bug
+    // for those passes. For value-level passes (constant_folding,
+    // simplify_locals, eliminate_dead_code, optimize_added_constants,
+    // simplify_branches, merge_blocks, vacuum, remove_unused_branches,
+    // optimize_advanced_instructions), the transforms do not move code
+    // across branches, so the silent skip is acceptable.
+    //
+    // To make this VISIBLE rather than silent, emit a one-line diagnostic so
+    // operators see how often verification is bypassed. The structured
+    // VerificationCoverage tracker (see verify_function_equivalence_with_result)
+    // records counts.
     if contains_unverifiable_instructions(&original.instructions)
         || contains_unverifiable_instructions(&optimized.instructions)
     {
-        return Ok(true); // Assume equivalent - can't prove without precise model
+        let reason = if contains_memory_instructions(&original.instructions)
+            || contains_memory_instructions(&optimized.instructions)
+        {
+            "float load/store"
+        } else {
+            "unknown opcode"
+        };
+        eprintln!(
+            "{}: verification skipped (unverifiable instructions: {})",
+            pass_name, reason
+        );
+        return Ok(true); // Assume equivalent — can't prove without precise model
     }
 
     // Create Z3 context and solver using thread-local context
@@ -1629,7 +1655,18 @@ pub fn verify_function_equivalence(
                     )),
                 }
             }
-            (Ok(None), Ok(None)) => Ok(true), // Both void functions
+            (Ok(None), Ok(None)) => {
+                // Both functions return no value (void). Currently auto-pass.
+                //
+                // KNOWN LIMITATION: void functions can still have side effects
+                // (memory writes, global writes) that differ between original
+                // and optimized. The current model does not assert equivalence
+                // of post-state locals/globals/memory — only the top-of-stack
+                // return value. For void functions there is no return value
+                // so the equivalence is vacuous. A future verifier upgrade
+                // should encode side-effect equivalence for these.
+                Ok(true)
+            }
             (Err(e), _) => Err(anyhow!("{}: Failed to encode original: {}", pass_name, e)),
             (_, Err(e)) => Err(anyhow!("{}: Failed to encode optimized: {}", pass_name, e)),
             _ => Err(anyhow!(
@@ -1869,11 +1906,37 @@ pub fn verify_function_equivalence_with_context(
     }
 
     // Skip verification for functions containing imprecisely-modeled instructions
-    // (memory ops, unknown ops) - these would produce false counterexamples
+    // (float load/store, unknown ops) — these would produce false counterexamples.
+    //
+    // KNOWN LIMITATION: returning Ok(true) here means callers' verify_or_revert
+    // accept the transform without proof. PR-B added pass-level hoist guards
+    // (LICM, CSE, code_folding, coalesce_locals) that skip BrIf/BrTable
+    // functions entirely, so the silent skip cannot mask a hoisting bug
+    // for those passes. For value-level passes (constant_folding,
+    // simplify_locals, eliminate_dead_code, optimize_added_constants,
+    // simplify_branches, merge_blocks, vacuum, remove_unused_branches,
+    // optimize_advanced_instructions), the transforms do not move code
+    // across branches, so the silent skip is acceptable.
+    //
+    // To make this VISIBLE rather than silent, emit a one-line diagnostic so
+    // operators see how often verification is bypassed. The structured
+    // VerificationCoverage tracker (see verify_function_equivalence_with_result)
+    // records counts.
     if contains_unverifiable_instructions(&original.instructions)
         || contains_unverifiable_instructions(&optimized.instructions)
     {
-        return Ok(true); // Assume equivalent - can't prove without precise model
+        let reason = if contains_memory_instructions(&original.instructions)
+            || contains_memory_instructions(&optimized.instructions)
+        {
+            "float load/store"
+        } else {
+            "unknown opcode"
+        };
+        eprintln!(
+            "{}: verification skipped (unverifiable instructions: {})",
+            pass_name, reason
+        );
+        return Ok(true); // Assume equivalent — can't prove without precise model
     }
 
     // Create Z3 context and solver using thread-local context
@@ -1913,7 +1976,18 @@ pub fn verify_function_equivalence_with_context(
                     )),
                 }
             }
-            (Ok(None), Ok(None)) => Ok(true), // Both void functions
+            (Ok(None), Ok(None)) => {
+                // Both functions return no value (void). Currently auto-pass.
+                //
+                // KNOWN LIMITATION: void functions can still have side effects
+                // (memory writes, global writes) that differ between original
+                // and optimized. The current model does not assert equivalence
+                // of post-state locals/globals/memory — only the top-of-stack
+                // return value. For void functions there is no return value
+                // so the equivalence is vacuous. A future verifier upgrade
+                // should encode side-effect equivalence for these.
+                Ok(true)
+            }
             (Err(e), _) => Err(anyhow!("{}: Failed to encode original: {}", pass_name, e)),
             (_, Err(e)) => Err(anyhow!("{}: Failed to encode optimized: {}", pass_name, e)),
             _ => Err(anyhow!(

--- a/loom-core/tests/optimization_tests.rs
+++ b/loom-core/tests/optimization_tests.rs
@@ -2912,3 +2912,107 @@ fn test_locals_in_nested_blocks() {
     wasmparser::validate(&wasm_bytes)
         .expect("Local operations in nested blocks should produce valid WASM");
 }
+
+// ============================================================================
+// Hoist soundness regression: default-then-override across br_table
+// ============================================================================
+//
+// This pattern tests that PR-B's hoist guards correctly skip optimization on
+// functions where path-sensitive local-state analysis matters. The pattern:
+//
+//   1. default-set local L = WAKE (1)
+//   2. br_table dispatcher; one arm "br 2" exits the outer block
+//   3. fall-through arm overrides L = INCREMENT (0)
+//   4. tail returns L
+//
+// On the "br 2" arm, L stays WAKE. On the fall-through arm, L becomes
+// INCREMENT. Hoisting "L = 0" to before the dispatcher would make L
+// always INCREMENT — breaking the WAKE arm.
+//
+// The Z3 verifier today is path-insensitive (top-of-stack-only equivalence,
+// BrTable as opaque terminator). Without PR-B's guards, hoist-prone passes
+// like LICM/CSE could collapse the default-then-override pattern and the
+// verifier would silently accept it. PR-B guards prevent the transform
+// from being attempted on these functions.
+
+#[test]
+fn test_default_then_override_across_br_table_preserved() {
+    // Function semantics:
+    //   - Default L=1 (WAKE) at function entry
+    //   - br_table to one of three targets based on input
+    //   - Fall-through: L=0 (INCREMENT)
+    //   - Returns: L
+    //
+    // Expected: optimizer must not collapse the default-then-override into
+    //   "L = 0 always before br_table" — that would break the WAKE arm.
+    let input = r#"
+        (module
+            (func $decide (param $kind i32) (result i32)
+                (local $action i32)
+                (local.set $action (i32.const 1))
+                (block
+                    (block
+                        (block
+                            (block
+                                (local.get $kind)
+                                (br_table 0 1 2 3)
+                            )
+                            (return (local.get $action))
+                        )
+                        (local.set $action (i32.const 0))
+                        (return (local.get $action))
+                    )
+                    (return (local.get $action))
+                )
+                (local.get $action)
+            )
+        )
+    "#;
+
+    let mut module = parse::parse_wat(input).unwrap();
+    optimize::optimize_module(&mut module).expect("optimization should not fail");
+
+    let wasm_bytes = encode::encode_wasm(&module).expect("encode should succeed");
+    wasmparser::validate(&wasm_bytes).expect("output must be valid WASM");
+
+    // The output must still contain at least one local.set with value 1
+    // (the WAKE default) — otherwise the optimizer collapsed the pattern.
+    use loom_core::Instruction;
+
+    fn has_const_one_local_set(instrs: &[Instruction]) -> bool {
+        let mut last_was_const_1 = false;
+        for instr in instrs {
+            match instr {
+                Instruction::I32Const(1) => last_was_const_1 = true,
+                Instruction::LocalSet(_) if last_was_const_1 => return true,
+                Instruction::Block { body, .. } | Instruction::Loop { body, .. } => {
+                    if has_const_one_local_set(body) {
+                        return true;
+                    }
+                    last_was_const_1 = false;
+                }
+                Instruction::If {
+                    then_body,
+                    else_body,
+                    ..
+                } => {
+                    if has_const_one_local_set(then_body) || has_const_one_local_set(else_body) {
+                        return true;
+                    }
+                    last_was_const_1 = false;
+                }
+                _ => last_was_const_1 = false,
+            }
+        }
+        false
+    }
+
+    assert!(
+        has_const_one_local_set(&module.functions[0].instructions),
+        "default-set of WAKE (i32.const 1; local.set) must survive optimization. \
+         If it was hoisted/collapsed, the WAKE arm of the br_table is broken. \
+         See PR-B hoist guards (loop_invariant_code_motion, code_folding, \
+         coalesce_locals, eliminate_common_subexpressions) and PR-A z3-status.md \
+         for known model limitations."
+    );
+}


### PR DESCRIPTION
## Summary

Step 3 of v0.4.0 release sequence. Makes the verifier's silent skips visible and adds a regression test for the path-sensitive br_table pattern that motivated PR-B's pass-level hoist guards.

### What ships

- **Visible skip diagnostics** — verify.rs's silent Ok(true) for unverifiable instructions now emits a one-line eprintln with pass name + skip reason ("float load/store" or "unknown opcode"). Both verify_function_equivalence and verify_function_equivalence_with_context updated.
- **Documented limitations** — verifier code now carries KNOWN-LIMITATION comments at the silent-skip and void-auto-pass sites, with pointers to PR-B's pass-level guards and the deferred verifier-model work.
- **Regression test** — `test_default_then_override_across_br_table_preserved` exercises the WAKE/INCREMENT default-then-override pattern across br_table and asserts the default i32.const 1; local.set survives optimization. Passes because PR-B's hoist guards skip those functions.

### What's NOT in this PR (intentionally)

The audit recommended three deeper fixes that are deferred to a follow-up PR after v0.4.0 ships:

- Compare full exit state (return + locals + globals + memory) rather than top-of-stack only
- Encode BrTable arms with path predicates and per-arm state merge
- Replace contains_unverifiable_instructions silent Ok(true) with a structured "verification skipped" return type so callers can decide per-pass policy

These require substantial encoder rework. PR-B + PR-C together neutralize the immediate hoist hole at the pass level; the deeper rework removes the underlying limitation.

## Test plan

- [x] cargo build --release passes
- [x] New regression test `test_default_then_override_across_br_table_preserved` passes
- [x] All other unit tests pass via pre-commit hook
- [ ] CI green

## Release sequence

| PR | Theme | Status |
|---|---|---|
| #81 | PR-A: stale artifacts + docs | Open |
| #83 | PR-B: hoist guards + encoder error path | Open |
| **(this)** | **PR-C: verifier skip diagnostics + regression test** | Open |
| - | PR-D: float-rule hardening + revert counter | Pending |
| - | PR-E: dead-code purge | Pending |
| - | PR-F: tag v0.4.0 | Pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)