### PR TITLE
release/v0.4.0 PR-D: per-pass revert counter for verification observability

### DIFF
--- a/loom-cli/src/main.rs
+++ b/loom-cli/src/main.rs
@@ -149,6 +149,22 @@ impl OptimizationStats {
                 println!("  (no effect: {})", inactive.join(", "));
             }
         }
+
+        // Per-pass revert summary — counts how many functions each pass
+        // tried to transform and then reverted because the Z3 verifier
+        // rejected the result. Non-zero counts indicate verification
+        // saved a potential miscompile.
+        let reverts = loom_core::stats::revert_summary();
+        if !reverts.is_empty() {
+            println!();
+            println!("🔁 Verification Reverts");
+            println!("─────────────────────────────────────────");
+            for (pass, count) in &reverts {
+                println!("  {:30} {} function(s) reverted", pass, count);
+            }
+            let total: u64 = reverts.values().sum();
+            println!("  Total: {} revert(s)", total);
+        }
         println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     }
 

--- a/loom-core/src/component_optimizer.rs
+++ b/loom-core/src/component_optimizer.rs
@@ -291,6 +291,7 @@ fn optimize_core_module(module_bytes: &[u8]) -> Result<Vec<u8>> {
 
         if let Err(e) = pass_fn(&mut module) {
             eprintln!("  Pass '{}' failed (reverting): {}", pass_name, e);
+            crate::stats::record_revert(&format!("component:{}", pass_name));
             module.functions = saved_functions;
             continue;
         }
@@ -305,6 +306,7 @@ fn optimize_core_module(module_bytes: &[u8]) -> Result<Vec<u8>> {
                         "  Module invalid after '{}' pass (reverting): {}",
                         pass_name, e
                     );
+                    crate::stats::record_revert(&format!("component:{}/invalid", pass_name));
                     module.functions = saved_functions;
                 }
             }
@@ -313,6 +315,7 @@ fn optimize_core_module(module_bytes: &[u8]) -> Result<Vec<u8>> {
                     "  Encode failed after '{}' pass (reverting): {}",
                     pass_name, e
                 );
+                crate::stats::record_revert(&format!("component:{}/encode-failed", pass_name));
                 module.functions = saved_functions;
             }
         }

--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -13,6 +13,9 @@ pub use loom_isle::{Imm32, Imm64, Value, ValueData};
 /// Stack analysis module: compositional stack type system
 pub mod stack;
 
+/// Optimization observability counters (revert counts per pass).
+pub mod stats;
+
 /// Internal representation of a WebAssembly module
 #[derive(Debug, Clone)]
 pub struct Module {
@@ -6920,6 +6923,7 @@ pub mod optimize {
             // instructions and continue optimizing other functions.
             if let Err(e) = translator.verify(func) {
                 eprintln!("constant_folding: reverting function (Z3 rejected): {}", e);
+                crate::stats::record_revert("constant_folding");
                 func.instructions = original_instructions;
             }
         }
@@ -7700,6 +7704,7 @@ pub mod optimize {
             // Verify stack correctness and semantic equivalence — revert on failure
             if guard.validate(func).is_err() || translator.verify(func).is_err() {
                 eprintln!("simplify_locals: reverting function (verification rejected)");
+                crate::stats::record_revert("simplify_locals");
                 func.instructions = original_instructions;
             }
         }
@@ -9810,6 +9815,7 @@ pub mod optimize {
             // Z3 translation validation — revert on failure
             if let Err(e) = translator.verify(func) {
                 eprintln!("coalesce_locals: reverting function (Z3 rejected): {}", e);
+                crate::stats::record_revert("coalesce_locals");
                 func.instructions = original_instructions;
                 func.locals = original_locals;
             }
@@ -10982,6 +10988,7 @@ pub mod optimize {
                 eprintln!(
                     "optimize_advanced_instructions: reverting function (verification rejected)"
                 );
+                crate::stats::record_revert("optimize_advanced_instructions");
                 func.instructions = original_instructions;
             }
         }

--- a/loom-core/src/stats.rs
+++ b/loom-core/src/stats.rs
@@ -1,0 +1,90 @@
+//! Optimization observability counters.
+//!
+//! When a pass attempts a transformation that the Z3 verifier rejects,
+//! the per-function `verify_or_revert` mechanism reverts the function
+//! to its pre-pass instructions and locals. Without instrumentation
+//! these reverts are silent — the build reports "success" even when
+//! every function in a module reverted.
+//!
+//! This module records revert counts by pass name so callers (CLI
+//! `--stats`, CI gates, tests) can observe how often verification
+//! actually catches and reverts a transform.
+//!
+//! Counters are global and process-wide; tests and CLI invocations
+//! that want isolated counts should call `take_revert_summary()`
+//! between runs.
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+fn counters() -> &'static Mutex<BTreeMap<String, u64>> {
+    static COUNTERS: OnceLock<Mutex<BTreeMap<String, u64>>> = OnceLock::new();
+    COUNTERS.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// Increment the revert counter for the named pass.
+pub fn record_revert(pass_name: &str) {
+    let mut map = counters().lock().expect("revert counter mutex poisoned");
+    *map.entry(pass_name.to_string()).or_insert(0) += 1;
+}
+
+/// Read a snapshot of the current revert counters.
+///
+/// Returns a sorted map (pass name → revert count). Counters are not
+/// reset; use `take_revert_summary` for read-and-reset semantics.
+pub fn revert_summary() -> BTreeMap<String, u64> {
+    counters()
+        .lock()
+        .expect("revert counter mutex poisoned")
+        .clone()
+}
+
+/// Read the current revert counters and reset them to zero.
+///
+/// Useful for tests that want to assert on revert counts without
+/// being affected by other tests in the same process.
+pub fn take_revert_summary() -> BTreeMap<String, u64> {
+    let mut map = counters().lock().expect("revert counter mutex poisoned");
+    let snapshot = map.clone();
+    map.clear();
+    snapshot
+}
+
+/// Total reverts across all passes.
+pub fn total_reverts() -> u64 {
+    counters()
+        .lock()
+        .expect("revert counter mutex poisoned")
+        .values()
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_and_read() {
+        // Use a unique pass name so we do not race with other tests
+        // that may run concurrently and share the global counter.
+        let pass = "stats_test_record_and_read";
+        record_revert(pass);
+        record_revert(pass);
+        record_revert(pass);
+
+        let summary = revert_summary();
+        assert_eq!(summary.get(pass).copied(), Some(3));
+    }
+
+    #[test]
+    fn take_resets() {
+        let pass = "stats_test_take_resets";
+        record_revert(pass);
+        let _ = take_revert_summary();
+        let summary = revert_summary();
+        assert!(
+            !summary.contains_key(pass),
+            "take_revert_summary should reset counters; pass still present"
+        );
+    }
+}

--- a/loom-core/src/verify.rs
+++ b/loom-core/src/verify.rs
@@ -2236,11 +2236,15 @@ impl TranslationValidator {
     /// Verify semantic equivalence; revert the function to its original
     /// instructions if verification fails. Returns true if verified, false
     /// if reverted. Never propagates errors — always safe to call.
+    ///
+    /// Reverts are recorded in `crate::stats::record_revert(pass_name)` so
+    /// callers can observe how often verification rejects a transform.
     pub fn verify_or_revert(&self, func: &mut Function) -> bool {
         match self.verify(func) {
             Ok(()) => true,
             Err(e) => {
                 eprintln!("{}: reverting function: {}", self.pass_name, e);
+                crate::stats::record_revert(&self.pass_name);
                 func.instructions = self.original.instructions.clone();
                 func.locals = self.original.locals.clone();
                 false


### PR DESCRIPTION
## Summary

Step 4 of v0.4.0 release sequence. Closes the silent-revert observability gap (R3 from the audit).

Until now, every revert via verify_or_revert or the manual revert sites in constant_folding, simplify_locals, coalesce_locals, optimize_advanced_instructions, and the component pipeline emitted an eprintln to stderr that vanished into CI logs. A pass that silently reverted every function still reported "success" — we had no way to detect mass-revert regressions.

## What ships

- New `loom_core::stats` module with process-global counter map (pass name → revert count).
- `record_revert`, `revert_summary`, `take_revert_summary`, `total_reverts` helpers.
- TranslationValidator::verify_or_revert now records reverts automatically.
- 4 manual revert sites in lib.rs wired: constant_folding, simplify_locals, coalesce_locals, optimize_advanced_instructions.
- 3 component-pipeline revert sites with namespaced keys (`component:<pass>`, `component:<pass>/invalid`, `component:<pass>/encode-failed`).
- CLI `--stats` output gains a "🔁 Verification Reverts" section.

## Float rule hardening — reclassified

The audit's S8-S11 items were investigated and most are out of v0.4.0 scope:

- **S10 trunc bounds**: current Rust `f as i32`/`f as i64` saturates (since 1.45); the bounds `f >= MIN as f && f < (MAX as f + 1.0)` correctly reject values >= 2^31 / 2^63 because f32/f64 representation rounds those values to exactly the boundary. The audit flagged a pre-1.45 UB concern that no longer applies.
- **S8/S9 sNaN canonicalization and host-FPU determinism**: real concerns but require switching to `rustc_apfloat` for bit-exact wasm semantics — out of scope.
- **S11 purity check on x op x → const**: real concern but PR-B's `has_dataflow_unsafe_control_flow` guard plus pass-level reverts catch the obvious cases; deferred to a dedicated PR.

## Test plan

- [x] cargo build --release passes
- [x] stats.rs ships 2 unit tests (record-and-read, take-resets) using unique per-test pass names to avoid races
- [x] Pre-commit hooks pass
- [ ] CI green

## Release sequence

| PR | Theme | Status |
|---|---|---|
| #81 | PR-A: stale artifacts + docs | Open |
| #83 | PR-B: hoist guards + encoder error path | Open |
| #84 | PR-C: verifier skip diagnostics + regression test | Open |
| **(this)** | **PR-D: per-pass revert counter** | Open |
| - | PR-E: dead-code purge | Pending |
| - | PR-F: tag v0.4.0 | Pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)