### PR TITLE
release/v0.5.0 PR-A: VerificationResult strict-mode helpers + gale v0.4.0 measurement

### DIFF
--- a/docs/research/gale-v0.4.0/measurement-report.md
+++ b/docs/research/gale-v0.4.0/measurement-report.md
@@ -1,0 +1,247 @@
+# LOOM vs wasm-opt — Gale (Zephyr-style scheduler FFI) measurement report
+
+Date: 2026-04-29
+LOOM: v0.4.0 (branch `feat/wave3-links-float-helpers`, commit `f15f593`)
+wasm-opt: binaryen v116
+Workload: `gale_ffi` cdylib (sem + timer + spinlock + ring_buf + bitarray + rbtree features)
+Source artifacts copied from
+`/Users/r/git/pulseengine/z/gale/benches/engine_control/build{,_noloom}/modules/gale/`.
+
+> Note on input. The "raw" cargo-rustc wasm32 output (`gale_ffi.wasm`)
+> was not present in the gale tree at measurement time and rebuilding it
+> required interactive cargo invocations that the harness blocked. The
+> available artifacts are post-`wasm-opt -Oz` (`gale_ffi.opt.wasm`,
+> 1941 bytes) and the production LOOM output (`gale_ffi.loom.wasm`,
+> 1913 bytes). The "baseline" in this report is therefore
+> `gale_ffi.opt.wasm` — i.e. wasm-opt -Oz output, which is what LOOM
+> consumes in the gale build pipeline.
+
+## 1. Byte-size table
+
+All sizes in bytes.
+
+| Variant | Whole-module | Code section | Δ vs baseline (whole) | Δ vs baseline (code only) |
+|---|---:|---:|---:|---:|
+| baseline (`gale_ffi.opt.wasm`, post wasm-opt -Oz) | 1941 | 811 | — | — |
+| **LOOM only** (this run, with attestation custom section) | 2863 | 862 | +47.5% | **+6.3%** |
+| LOOM only (production gale build, no attestation section) | 1913 | 862 | -1.4% | +6.3% |
+| **wasm-opt -O3 only** | 1925 | 795 | -0.8% | **-2.0%** |
+| **wasm-opt -O3 → LOOM** (with attestation) | 2841 | 846 | +46.4% | +4.3% |
+
+Key finding: on the actual code section, LOOM **regresses** size by +6.3%
+relative to wasm-opt-Oz baseline, while wasm-opt -O3 further reduces
+code size by -2.0%. The whole-module +47% on this run is dominated by
+LOOM's `wsc.transformation.attestation` custom section (~947 bytes),
+which the production gale pipeline strips. Stripping it brings the
+whole-module delta to -1.4%, but the code section is still larger.
+
+## 2. LOOM per-pass instruction-delta table
+
+LOOM-only run on `gale_ffi.opt.wasm` (1941 → 2863):
+
+| Pass | Instructions in → out | Δ |
+|---|---:|---:|
+| inline | 215 → 215 | 0 |
+| precompute | 215 → 215 | 0 |
+| constant-folding | 215 → 215 | 0 (both candidates reverted) |
+| **cse** | **215 → 219** | **+4** (added `local.tee N / local.get N` pairs that introduce new locals) |
+| advanced (`optimize_advanced_instructions`) | 219 → 219 | 0 (revert) |
+| branches | 219 → 219 | 0 |
+| dce | 219 → 219 | 0 |
+| merge-blocks | 219 → 219 | 0 |
+| vacuum | 219 → 219 | 0 |
+| simplify-locals | 219 → 219 | 0 |
+
+Final: 215 → 219 instructions. LOOM CLI reports this as
+"-1.9% reduction" — that is the `--stats` summary's percentage label
+for an *increase* of 4 instructions and is misleading; the absolute
+count went up.
+
+LOOM stats line: `Optimization effect: -1001 bytes reduction` is also
+misleading — it is computed against an internal re-encoded baseline
+(1862 bytes) rather than the input (1941 bytes). The true input → output
+delta is 1941 → 2863 (+922) or, stripping the attestation custom
+section, +51 bytes net (code section grew, custom section grew, other
+sections unchanged).
+
+## 3. LOOM revert-count summary
+
+| Pass | Reverts | Reason |
+|---|---:|---|
+| constant_folding | 1 | Z3 counterexample `param0 = 0xffffffff` |
+| optimize_advanced_instructions | 1 | Verifier counterexample (same shape) |
+| **Total** | **2** | |
+
+LOOM additionally reports it skipped 3 functions per pass with
+"dataflow-unsafe control flow (BrIf/BrTable, see #56)" — i.e. functions
+4, 24, and one of {19, 21} (the only `br_table` / heavy `br_if`
+functions in the workload, including `gale_k_sem_give_decide`).
+
+## 4. Top concrete wasm-opt-only transformations LOOM missed
+
+(Source: `diff baseline.wat wopt.wat`. Differences are small because the
+input is already wasm-opt -Oz; -O3 picks up only what -Oz left on the
+table.)
+
+### 4.1 Dead-store elimination of init-only locals
+
+wasm-opt removes locals that are written but never read.
+
+baseline (`func 0`, line 13-15):
+```
+(local i32)
+i32.const -22
+local.set 3
+```
+wopt: those three lines deleted entirely (the local was a
+sentinel-init that subsequent code overwrote on every path).
+
+Same pattern eliminated in `func 13` (`i32.const -16; local.set 1`)
+and `func 21` (`(local i32); i32.const -1; local.set 5`).
+
+LOOM keeps all of these (its `simplify-locals` pass had zero effect).
+
+### 4.2 Compare-operand canonicalization for register reuse
+
+baseline:
+```
+local.tee 0
+...
+local.get 0
+i32.lt_u
+```
+wopt:
+```
+local.tee 2
+...
+local.get 2
+i32.gt_u
+```
+Reorders operands and flips `lt_u` → `gt_u` so the live value can stay
+in the same physical register slot through the compare. Pure shape
+canonicalization; LOOM has no equivalent pass.
+
+### 4.3 Local-renumbering to compact the slot table
+
+baseline uses `local 3` for a one-shot temporary; wopt renames it to
+`local 1` (which was already declared) and drops the extra slot. Frees
+a local-decl byte from the function header. LOOM does the OPPOSITE —
+its CSE pass *adds* fresh locals (see 4.5).
+
+### 4.4 Removal of redundant constant materialization (LOOM does NOT undo this)
+
+baseline (`func 2`):
+```
+i32.const -22
+i32.const -22
+i32.const 0
+...
+```
+wopt leaves this as is — two adjacent `i32.const -22` is not redundant
+because both values are consumed by separate `select` instructions.
+Crucially, **LOOM rewrites this to**:
+```
+i32.const -22
+local.tee 5
+local.get 5      ;; "CSE" of a 2-byte constant
+i32.const 0
+```
+which adds two locals to the function header (`(local i32 i32 i32 i32)`)
+and replaces 2 bytes (`-22` is a single-byte LEB128 const that materializes
+as `41 6a`) with a 4-byte `local.tee N / local.get N` pair plus the
+header growth. Net regression on every small function with two
+adjacent identical small-constant pushes — and gale has many of these
+(`-22` = `-EINVAL`, `-16` = `-EBUSY`, `-1` = `K_FOREVER`).
+
+### 4.5 LOOM CSE bug — store hoisted ABOVE its null-check guard (`gale_sem_count_take` / `gale_sem_take_v2`)
+
+This is not a missed optimization; it is a soundness defect.
+
+baseline `func 16` (exported as both `gale_sem_count_take` and
+`gale_sem_take_v2`):
+```
+local.get 0           ;; sem ptr
+i32.eqz
+if
+  i32.const -22       ;; -EINVAL
+  return
+end
+local.get 0
+i32.load
+local.tee 1           ;; cnt
+i32.eqz
+if
+  i32.const -16       ;; -EBUSY
+  return
+end
+local.get 0
+local.get 1
+i32.const 1
+i32.sub
+i32.store             ;; *sem = cnt - 1
+i32.const 0
+```
+
+LOOM output:
+```
+local.get 0           ;; sem ptr
+local.get 1           ;; cnt (uninitialized local!)
+i32.const 1
+i32.sub
+i32.store             ;; *sem = (uninit - 1) — STORE HOISTED
+local.get 0
+i32.eqz
+if
+  i32.const -22
+  return
+end
+local.get 0
+i32.load
+local.tee 1
+i32.eqz
+if
+  i32.const -16
+  return
+end
+i32.const 0
+```
+
+The store is now executed unconditionally — including when `sem == 0`
+(would store to wasm linear address 0..3) and including before `cnt` is
+loaded (so the value written is whatever the un-initialized local 1
+holds, i.e. 0xffffffff after the implicit zero-init wraparound).
+wasm-opt does not perform this transformation.
+
+This was emitted by LOOM's `cse` pass without any verification revert
+(reverts only fired in `constant_folding` and `optimize_advanced`). It
+is a clear miscompile on a kernel-primitive entry point and indicates
+the CSE pass is not feeding into the same Z3 verification gate as the
+other passes.
+
+## 5. Conclusion
+
+> **LOOM's gap on gale-style code comes mostly from a CSE pass that
+> introduces new locals to deduplicate trivially-cheap constants
+> (turning a 2-byte `i32.const -22` into a 4-byte `local.tee/local.get`
+> plus a function-header growth) and that, on at least one
+> kernel-primitive entry point (`gale_sem_count_take`), hoists a store
+> above its null-pointer guard without going through Z3 verification —
+> simultaneously regressing code-section size by +6.3% and producing an
+> unsound transformation that wasm-opt -O3 does not.**
+
+Secondary gap: LOOM's `simplify-locals` pass had zero effect on this
+workload, so the dead-store-of-init-only-locals optimization (the bulk
+of what wasm-opt -O3 still finds after -Oz) is entirely unaddressed by
+LOOM.
+
+## Files
+
+All sizes/wat/wasm artifacts are in
+`/Users/r/git/pulseengine/loom/scripts/mythos/gale_measure/`:
+
+- `gale_in_baseline.wasm` — input (post wasm-opt -Oz, 1941 B)
+- `gale.loom.wasm` — LOOM only (2863 B incl. attestation, 862 B code)
+- `gale.wopt.wasm` — wasm-opt -O3 only (1925 B, 795 B code)
+- `gale.wopt-loom.wasm` — wasm-opt -O3 then LOOM (2841 B, 846 B code)
+- `baseline.wat`, `wopt.wat`, `loom.wat`, `wopt-loom.wat` — disassembly
+- `gale_in_already_loom.wasm` — production gale build's LOOM output (1913 B)

--- a/loom-core/src/verify.rs
+++ b/loom-core/src/verify.rs
@@ -483,7 +483,13 @@ pub enum VerificationResult {
 
 impl VerificationResult {
     /// Returns true if this result indicates the functions are equivalent
-    /// (either proven or assumed due to skipping)
+    /// (either proven or assumed due to skipping).
+    ///
+    /// **Lenient semantics**: counts skipped-due-to-unverifiable as
+    /// "equivalent" (the verifier couldn't prove a difference, so the
+    /// transform is allowed). Use this for value-level passes (constant
+    /// folding, simplify_locals, dead-code-elimination) where the
+    /// transforms cannot move code across branches.
     pub fn is_equivalent(&self) -> bool {
         matches!(
             self,
@@ -494,9 +500,40 @@ impl VerificationResult {
         )
     }
 
-    /// Returns true if this result was fully Z3-verified
+    /// Returns true if this result was fully Z3-verified.
+    ///
+    /// **Strict semantics**: only `Verified` counts. Skipped* and
+    /// counterexamples both return false. Use this for hoist-prone
+    /// passes (LICM, CSE, code_folding, coalesce_locals) where moving
+    /// code across branches is unsafe without a real proof — REQ-5
+    /// conservative-over-fast: "skip the function rather than risk
+    /// incorrect optimization."
     pub fn is_verified(&self) -> bool {
         matches!(self, VerificationResult::Verified)
+    }
+
+    /// Returns true if verification was skipped (any reason).
+    ///
+    /// Lets callers distinguish "verifier proved equivalence" from
+    /// "verifier could not reason about this input." The latter is the
+    /// audit's S5 finding: silent skips were being treated as success.
+    pub fn is_skip(&self) -> bool {
+        matches!(
+            self,
+            VerificationResult::SkippedLoop
+                | VerificationResult::SkippedMemory
+                | VerificationResult::SkippedUnknown
+        )
+    }
+
+    /// Human-readable skip reason, or `None` if not a skip outcome.
+    pub fn skip_reason(&self) -> Option<&'static str> {
+        match self {
+            VerificationResult::SkippedLoop => Some("complex loop"),
+            VerificationResult::SkippedMemory => Some("float load/store"),
+            VerificationResult::SkippedUnknown => Some("unknown opcode"),
+            _ => None,
+        }
     }
 
     /// Update coverage tracker based on this result
@@ -2246,6 +2283,14 @@ impl TranslationValidator {
     /// instructions if verification fails. Returns true if verified, false
     /// if reverted. Never propagates errors — always safe to call.
     ///
+    /// **Lenient semantics**: silent skips on unverifiable instructions
+    /// (float load/store, unknown opcodes, complex loops) are treated as
+    /// "verified" and the transform is kept. Use this for value-level
+    /// passes that cannot move code across branches.
+    ///
+    /// For hoist-prone passes (LICM, CSE, code_folding, coalesce_locals),
+    /// use [`Self::verify_or_revert_strict`] instead.
+    ///
     /// Reverts are recorded in `crate::stats::record_revert(pass_name)` so
     /// callers can observe how often verification rejects a transform.
     pub fn verify_or_revert(&self, func: &mut Function) -> bool {
@@ -2258,6 +2303,57 @@ impl TranslationValidator {
                 func.locals = self.original.locals.clone();
                 false
             }
+        }
+    }
+
+    /// Verify semantic equivalence with strict semantics: a *skipped*
+    /// verification (verifier could not reason about this input) counts
+    /// as failure and the function is reverted. Only `VerificationResult::Verified`
+    /// is accepted. Returns true if verified, false if reverted.
+    ///
+    /// Use this for hoist-prone passes (LICM, CSE, code_folding,
+    /// coalesce_locals) where moving code across branches is unsafe
+    /// without a real proof — REQ-5 conservative-over-fast.
+    ///
+    /// Reverts are recorded in `crate::stats::record_revert("<pass>:strict-skip")`
+    /// for skip-induced reverts and `crate::stats::record_revert("<pass>")`
+    /// for genuine counterexamples.
+    pub fn verify_or_revert_strict(&self, func: &mut Function) -> bool {
+        let result = verify_function_equivalence_with_result(&self.original, func, &self.pass_name);
+        match result {
+            VerificationResult::Verified => true,
+            VerificationResult::Failed(reason) => {
+                eprintln!(
+                    "{}: reverting function (counterexample): {}",
+                    self.pass_name, reason
+                );
+                crate::stats::record_revert(&self.pass_name);
+                func.instructions = self.original.instructions.clone();
+                func.locals = self.original.locals.clone();
+                false
+            }
+            VerificationResult::Error(reason) => {
+                eprintln!(
+                    "{}: reverting function (verification error): {}",
+                    self.pass_name, reason
+                );
+                crate::stats::record_revert(&self.pass_name);
+                func.instructions = self.original.instructions.clone();
+                func.locals = self.original.locals.clone();
+                false
+            }
+            r if r.is_skip() => {
+                let reason = r.skip_reason().unwrap_or("unknown");
+                eprintln!(
+                    "{}: reverting function (strict mode rejects skip: {})",
+                    self.pass_name, reason
+                );
+                crate::stats::record_revert(&format!("{}:strict-skip", self.pass_name));
+                func.instructions = self.original.instructions.clone();
+                func.locals = self.original.locals.clone();
+                false
+            }
+            _ => true, // unreachable in practice
         }
     }
 
@@ -2323,6 +2419,14 @@ impl TranslationValidator {
     /// Stub verify_or_revert - always returns true when verification disabled
     pub fn verify_or_revert(&self, _func: &mut crate::Function) -> bool {
         true
+    }
+
+    /// Stub verify_or_revert_strict — when verification is disabled, there
+    /// is no Z3 model to consult, so we conservatively revert (REQ-5).
+    /// In practice this means hoist-prone passes are no-ops in non-Z3
+    /// builds; they should already be guarded by has_dataflow_unsafe_control_flow.
+    pub fn verify_or_revert_strict(&self, _func: &mut crate::Function) -> bool {
+        false
     }
 }
 
@@ -7056,5 +7160,66 @@ mod tests {
             result.unwrap(),
             "memory.fill should not affect local variables in Z3 model"
         );
+    }
+
+    // ======================================================================
+    // VerificationResult skip-disambiguation tests (v0.5.0 PR-A)
+    //
+    // The audit's S5 finding: callers couldn't tell "Z3 proved equivalence"
+    // from "verifier silently bailed because input was unverifiable." These
+    // tests pin the strict/lenient distinction added in v0.5.0.
+    // ======================================================================
+
+    #[test]
+    fn verification_result_lenient_treats_skip_as_equivalent() {
+        // Lenient mode (existing is_equivalent): skipped == equivalent.
+        // Used by value-level passes that don't move code across branches.
+        assert!(VerificationResult::Verified.is_equivalent());
+        assert!(VerificationResult::SkippedLoop.is_equivalent());
+        assert!(VerificationResult::SkippedMemory.is_equivalent());
+        assert!(VerificationResult::SkippedUnknown.is_equivalent());
+        assert!(!VerificationResult::Failed("cex".into()).is_equivalent());
+        assert!(!VerificationResult::Error("err".into()).is_equivalent());
+    }
+
+    #[test]
+    fn verification_result_strict_only_accepts_verified() {
+        // Strict mode (existing is_verified): only Verified counts.
+        // Used by hoist-prone passes (LICM, CSE, code_folding, coalesce_locals).
+        assert!(VerificationResult::Verified.is_verified());
+        assert!(!VerificationResult::SkippedLoop.is_verified());
+        assert!(!VerificationResult::SkippedMemory.is_verified());
+        assert!(!VerificationResult::SkippedUnknown.is_verified());
+        assert!(!VerificationResult::Failed("cex".into()).is_verified());
+        assert!(!VerificationResult::Error("err".into()).is_verified());
+    }
+
+    #[test]
+    fn verification_result_skip_predicate_distinguishes_skip_from_proof() {
+        // is_skip() lets callers detect "verifier couldn't reason" cases.
+        assert!(!VerificationResult::Verified.is_skip());
+        assert!(VerificationResult::SkippedLoop.is_skip());
+        assert!(VerificationResult::SkippedMemory.is_skip());
+        assert!(VerificationResult::SkippedUnknown.is_skip());
+        assert!(!VerificationResult::Failed("cex".into()).is_skip());
+        assert!(!VerificationResult::Error("err".into()).is_skip());
+    }
+
+    #[test]
+    fn verification_result_skip_reason_human_readable() {
+        assert_eq!(VerificationResult::Verified.skip_reason(), None);
+        assert_eq!(
+            VerificationResult::SkippedLoop.skip_reason(),
+            Some("complex loop")
+        );
+        assert_eq!(
+            VerificationResult::SkippedMemory.skip_reason(),
+            Some("float load/store")
+        );
+        assert_eq!(
+            VerificationResult::SkippedUnknown.skip_reason(),
+            Some("unknown opcode")
+        );
+        assert_eq!(VerificationResult::Failed("x".into()).skip_reason(), None);
     }
 }


### PR DESCRIPTION
## Summary

First PR of the v0.5.0 release. Two parts:

1. **Closes audit S5** — gives passes a way to distinguish "Z3 proved equivalence" from "verifier silently bailed because input was unverifiable." The existing `VerificationResult` enum already carried the variants; this PR adds the predicates and a strict-mode revert helper so callers opt into "skip = unsafe to optimize."

2. **Documents v0.4.0 gale measurement** in \`docs/research/gale-v0.4.0/measurement-report.md\`. Critical finding: CSE produces an UNSOUND store-hoist on \`gale_sem_count_take\` because the v0.4.0 hoist guard only checks BrIf/BrTable, not Return/Br. Fixed in v0.5.0 PR-B.

## verify.rs additions

- \`VerificationResult::is_skip()\` — true for SkippedLoop / SkippedMemory / SkippedUnknown; false for Verified / Failed / Error.
- \`VerificationResult::skip_reason()\` — human-readable skip cause.
- \`TranslationValidator::verify_or_revert_strict()\` — strict counterpart to \`verify_or_revert\`. Reverts on Skipped*, Failed, or Error; only Verified is accepted. Recorded under \`<pass>:strict-skip\` stat key.
- Stub for non-verification builds returns false (REQ-5 conservative-over-fast).
- Doc comments name lenient/strict semantics explicitly.

4 unit tests covering lenient/strict/is_skip/skip_reason.

## Test plan

- [x] cargo build --release passes
- [x] All unit tests pass via pre-commit
- [ ] CI green

## v0.5.0 release sequence

| PR | Theme | Status |
|---|---|---|
| **(this)** | **PR-A: VerificationResult strict mode + gale measurement** | Open |
| - | PR-B: Extend hoist guard to Return/Br (CSE soundness fix) | Pending |
| - | PR-C: Spec-feature corpus fixtures | Pending |
| - | PR-D: FusedOptimization.v in BUILD.bazel | Pending |
| - | PR-E: Tag v0.5.0 | Pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)