### PR TITLE
release/v0.5.0 PR-B: close hoist hole on early-exit (Return/Br) patterns

### DIFF
--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -6711,15 +6711,54 @@ pub mod optimize {
     /// - `test_advanced_optimizations_in_control_flow` (ignored test demonstrating the gap)
     /// - `constant_folding()` and `optimize_advanced_instructions()` which call this function
     fn has_dataflow_unsafe_control_flow(func: &Function) -> bool {
-        has_dataflow_unsafe_control_flow_in_block(&func.instructions)
-    }
-
-    fn has_dataflow_unsafe_control_flow_in_block(instructions: &[Instruction]) -> bool {
-        for instr in instructions {
+        // Top-level scan: BrIf/BrTable are always unsafe. Br/Return are safe
+        // only at the very last position (where they act as the function
+        // terminator). Anywhere else they create early-exit paths.
+        let n = func.instructions.len();
+        for (i, instr) in func.instructions.iter().enumerate() {
             match instr {
                 Instruction::BrIf { .. } | Instruction::BrTable { .. } => return true,
+                Instruction::Br(_) | Instruction::Return
+                    // Tail position is fine — that's just the function ending.
+                    if i + 1 != n => {
+                        return true;
+                    }
                 Instruction::Block { body, .. } | Instruction::Loop { body, .. }
-                    if has_dataflow_unsafe_control_flow_in_block(body) =>
+                    if has_unsafe_in_nested(body) => {
+                        return true;
+                    }
+                Instruction::If {
+                    then_body,
+                    else_body,
+                    ..
+                }
+                    if (has_unsafe_in_nested(then_body) || has_unsafe_in_nested(else_body)) => {
+                        return true;
+                    }
+                _ => {}
+            }
+        }
+        false
+    }
+
+    /// Inside a nested block/loop/if body, ANY Br/BrIf/BrTable/Return is an
+    /// early-exit pattern — the surrounding expression has another path that
+    /// skips the rest of the function. Hoisting code across these is unsound
+    /// without a path-sensitive verifier.
+    ///
+    /// This is what the v0.4.0 audit's gale_sem_count_take CSE bug needed:
+    /// the function had `if (eqz) return; end` (a Return inside an If body),
+    /// which the previous BrIf-only check did not flag. CSE then hoisted an
+    /// i32.store above the guard, producing an unsound transformation.
+    fn has_unsafe_in_nested(instructions: &[Instruction]) -> bool {
+        for instr in instructions {
+            match instr {
+                Instruction::BrIf { .. }
+                | Instruction::BrTable { .. }
+                | Instruction::Br(_)
+                | Instruction::Return => return true,
+                Instruction::Block { body, .. } | Instruction::Loop { body, .. }
+                    if has_unsafe_in_nested(body) =>
                 {
                     return true;
                 }
@@ -6727,9 +6766,7 @@ pub mod optimize {
                     then_body,
                     else_body,
                     ..
-                } if (has_dataflow_unsafe_control_flow_in_block(then_body)
-                    || has_dataflow_unsafe_control_flow_in_block(else_body)) =>
-                {
+                } if (has_unsafe_in_nested(then_body) || has_unsafe_in_nested(else_body)) => {
                     return true;
                 }
                 _ => {}
@@ -6844,7 +6881,7 @@ pub mod optimize {
         use super::Value;
         use super::terms::TermSignatureContext;
         use crate::verify::{TranslationValidator, VerificationSignatureContext};
-        use loom_isle::{LocalEnv, rewrite_pure, rewrite_with_dataflow};
+        use loom_isle::{LocalEnv, rewrite_with_dataflow};
 
         // Create signature contexts before mutating functions
         // TermSignatureContext for ISLE term conversion
@@ -6865,12 +6902,18 @@ pub mod optimize {
             }
 
             // Determine if this function has control flow that makes
-            // dataflow env tracking unsafe. If so, we still run ISLE but
-            // with a frozen (empty) env — pure pattern rewrites still apply
-            // (constant folding, algebraic identities, strength reduction).
-            let use_dataflow_env = !has_dataflow_unsafe_control_flow(func);
-            if !use_dataflow_env {
+            // dataflow env tracking unsafe. If so, skip the entire function:
+            // even rewrite_pure goes through instructions_to_terms /
+            // terms_to_instructions, and that round-trip is not guaranteed
+            // to preserve instruction order across early-exit patterns
+            // (Return inside If/Block). The gale_sem_count_take regression
+            // (v0.4.0 audit) reproduced exactly this — terms_to_instructions
+            // emitted the if-guard AFTER the function-tail straight-line
+            // code, hoisting an i32.store above its null-pointer guard.
+            // REQ-5 conservative-over-fast.
+            if has_dataflow_unsafe_control_flow(func) {
                 skipped_control_flow += 1;
+                continue;
             }
 
             // Capture original for translation validation (Z3 proof of semantic equivalence)
@@ -6892,18 +6935,17 @@ pub mod optimize {
                 &term_sig_ctx,
             ) {
                 if !terms.is_empty() {
-                    let optimized_terms: Vec<Value> = if use_dataflow_env {
-                        // Full dataflow: track local assignments across straight-line code
-                        let mut env = LocalEnv::new();
-                        terms
-                            .into_iter()
-                            .map(|term| rewrite_with_dataflow(term, &mut env))
-                            .collect()
-                    } else {
-                        // No dataflow env: pure pattern rewrites only (safe for control flow).
-                        // Each term is simplified independently — no cross-term local propagation.
-                        terms.into_iter().map(rewrite_pure).collect()
-                    };
+                    // Always use dataflow env: the unsafe-control-flow path
+                    // is now skipped above (see comment on
+                    // has_dataflow_unsafe_control_flow). The previous
+                    // rewrite_pure fallback unsoundly reordered code on
+                    // early-exit patterns via the terms-to-instructions
+                    // round-trip; it's been removed.
+                    let mut env = LocalEnv::new();
+                    let optimized_terms: Vec<Value> = terms
+                        .into_iter()
+                        .map(|term| rewrite_with_dataflow(term, &mut env))
+                        .collect();
                     if let Ok(mut new_instrs) =
                         super::terms::terms_to_instructions(&optimized_terms)
                     {
@@ -6956,6 +6998,12 @@ pub mod optimize {
             if has_unknown_instructions(func) || has_unsupported_isle_instructions(func) {
                 continue;
             }
+
+            // DCE only deletes unreachable code after Return/Br/Unreachable
+            // terminators. It does not reorder reachable code, so the
+            // early-exit hoist concern that motivated guards on other passes
+            // does not apply here. (Function-tail Return is the primary
+            // reason DCE exists.)
 
             // Create validation guard with module context for Call validation
             let guard = ValidationGuard::with_context(func, "eliminate_dead_code", ctx.clone());
@@ -7647,6 +7695,15 @@ pub mod optimize {
         for func in &mut module.functions {
             // Skip functions with unsupported instructions (can't verify)
             if has_unknown_instructions(func) || has_unsupported_isle_instructions(func) {
+                continue;
+            }
+
+            // Skip early-exit functions: simplify_locals (RSE / local-merge)
+            // can move local.set / local.get sequences across guard
+            // boundaries when those guards are `if (cond) return ...`.
+            // The verifier is path-insensitive across these (REQ-5,
+            // gale_sem_count_take regression).
+            if has_dataflow_unsafe_control_flow(func) {
                 continue;
             }
 
@@ -9501,6 +9558,12 @@ pub mod optimize {
                 continue;
             }
 
+            // Skip early-exit functions — branch-removal can restructure
+            // control flow across guard boundaries (REQ-5).
+            if has_dataflow_unsafe_control_flow(func) {
+                continue;
+            }
+
             let guard = ValidationGuard::with_context(func, "remove_unused_branches", ctx.clone());
 
             // Capture original for translation validation (Z3 proof of semantic equivalence)
@@ -9612,6 +9675,11 @@ pub mod optimize {
         for func in &mut module.functions {
             // Skip functions with unsupported instructions (can't verify)
             if has_unknown_instructions(func) || has_unsupported_isle_instructions(func) {
+                continue;
+            }
+
+            // Skip early-exit functions (REQ-5 conservative-over-fast).
+            if has_dataflow_unsafe_control_flow(func) {
                 continue;
             }
 
@@ -10915,7 +10983,7 @@ pub mod optimize {
         use super::terms::TermSignatureContext;
         use crate::stack::validation::{ValidationContext, ValidationGuard};
         use crate::verify::{TranslationValidator, VerificationSignatureContext};
-        use loom_isle::{LocalEnv, rewrite_pure, rewrite_with_dataflow};
+        use loom_isle::{LocalEnv, rewrite_with_dataflow};
 
         let ctx = ValidationContext::from_module(module);
         // Create signature contexts for proper Call/CallIndirect handling
@@ -10934,9 +11002,11 @@ pub mod optimize {
                 continue;
             }
 
-            let use_dataflow_env = !has_dataflow_unsafe_control_flow(func);
-            if !use_dataflow_env {
+            // Same skip as constant_folding: terms_to_instructions roundtrip
+            // does not preserve order across early-exit patterns. REQ-5.
+            if has_dataflow_unsafe_control_flow(func) {
                 skipped_control_flow += 1;
+                continue;
             }
 
             let guard =
@@ -10959,15 +11029,12 @@ pub mod optimize {
                 &term_sig_ctx,
             ) {
                 if !terms.is_empty() {
-                    let optimized_terms: Vec<Value> = if use_dataflow_env {
-                        let mut env = LocalEnv::new();
-                        terms
-                            .into_iter()
-                            .map(|term| rewrite_with_dataflow(term, &mut env))
-                            .collect()
-                    } else {
-                        terms.into_iter().map(rewrite_pure).collect()
-                    };
+                    // Always use dataflow env (same reasoning as constant_folding).
+                    let mut env = LocalEnv::new();
+                    let optimized_terms: Vec<Value> = terms
+                        .into_iter()
+                        .map(|term| rewrite_with_dataflow(term, &mut env))
+                        .collect();
 
                     if let Ok(new_instructions) =
                         super::terms::terms_to_instructions(&optimized_terms)

--- a/loom-core/tests/optimization_tests.rs
+++ b/loom-core/tests/optimization_tests.rs
@@ -3016,3 +3016,93 @@ fn test_default_then_override_across_br_table_preserved() {
          for known model limitations."
     );
 }
+
+// ============================================================================
+// Hoist soundness regression: early-exit pattern (gale_sem_count_take)
+// ============================================================================
+//
+// v0.4.0 audit found CSE produced an unsound store-hoist on
+// gale_sem_count_take: an `if (eqz) return; end` early-exit guard followed
+// by an i32.store had the store hoisted ABOVE the guard, so the store ran
+// even when the input was null. The v0.4.0 hoist guard only flagged
+// BrIf/BrTable functions; this function uses If+Return, which slipped
+// through.
+//
+// v0.5.0 PR-B extends `has_dataflow_unsafe_control_flow` to flag any
+// nested Return/Br as an early-exit pattern. This test pins that the
+// store-after-guard pattern survives optimization unchanged.
+
+#[test]
+fn test_early_return_guard_prevents_store_hoist() {
+    // Mirrors gale_sem_count_take: null-pointer guard with early `return`,
+    // then a store of a derived value. If LOOM hoists the store above
+    // the guard, the test will fail because the store will appear before
+    // the (i32.eqz) check in the optimized output.
+    let input = r#"
+        (module
+            (memory 1)
+            (func $sem_take (param $sem i32) (result i32)
+                ;; null-pointer guard: if sem == 0, return -EINVAL early
+                (if (i32.eqz (local.get $sem))
+                    (then
+                        (return (i32.const -22))
+                    )
+                )
+                ;; only safe to load/store when sem != 0
+                (local.get $sem)
+                (i32.load (local.get $sem))
+                (i32.const 1)
+                (i32.sub)
+                (i32.store)
+                (i32.const 0)
+            )
+        )
+    "#;
+
+    let mut module = parse::parse_wat(input).unwrap();
+    optimize::optimize_module(&mut module).expect("optimization should not fail");
+
+    let wasm_bytes = encode::encode_wasm(&module).expect("encode should succeed");
+    wasmparser::validate(&wasm_bytes).expect("output must be valid WASM");
+
+    // The guard must come before the store. We check this by finding the
+    // first I32Eqz and the first I32Store and asserting the order.
+    use loom_core::Instruction;
+
+    fn find_first(instrs: &[Instruction], target: &str) -> Option<usize> {
+        for (i, instr) in instrs.iter().enumerate() {
+            let name = format!("{:?}", instr);
+            if name.starts_with(target) {
+                return Some(i);
+            }
+            // Recurse into nested bodies — guard in If/Block, store may be
+            // anywhere. The order at the top level is what matters for
+            // gale_sem_count_take's flat layout.
+            match instr {
+                Instruction::Block { body, .. } | Instruction::Loop { body, .. }
+                    if find_first(body, target).is_some() =>
+                {
+                    return Some(i);
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    let func = &module.functions[0];
+    let eqz_idx =
+        find_first(&func.instructions, "I32Eqz").expect("guard's I32Eqz must survive optimization");
+    let store_idx =
+        find_first(&func.instructions, "I32Store").expect("store must survive optimization");
+
+    assert!(
+        eqz_idx < store_idx,
+        "i32.store ({store_idx}) hoisted ABOVE i32.eqz guard ({eqz_idx})! \
+         This is the gale_sem_count_take CSE soundness bug from v0.4.0 — \
+         the store now runs unconditionally including when sem == 0. \
+         See docs/research/gale-v0.4.0/measurement-report.md for context. \
+         v0.5.0 PR-B fixes this by extending has_dataflow_unsafe_control_flow \
+         to flag any nested Return/Br as an early-exit pattern."
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the CSE soundness bug discovered on `gale_sem_count_take` (documented in PR-A's gale measurement report). The v0.4.0 hoist guard only flagged `BrIf/BrTable`; functions using `if (cond) return; end` (the canonical Rust early-exit guard) slipped through.

## Root cause

Per-pass tracing on a gale-style fixture showed the reordering happens in `constant_folding`, not in CSE as initially suspected. The `instructions_to_terms` → rewrite → `terms_to_instructions` round-trip does not preserve order across early-exit patterns: a function with `If { then_body: [..., Return] }` followed by straight-line code emerges with the if-block moved to the function tail and the straight-line code (load/sub/store) hoisted to the function head — so the store runs unconditionally, including when the guard would have returned early.

## Fix

- Extend `has_dataflow_unsafe_control_flow` to flag any nested `Return/Br` as an early-exit pattern. New helper `has_unsafe_in_nested` recurses into Block/Loop/If bodies. Top-level Return/Br at the very last position is allowed (function terminator).
- `constant_folding` and `optimize_advanced_instructions` now skip the function entirely when `has_dataflow_unsafe_control_flow` is true. Previously they fell back to `rewrite_pure`, which still went through the unsound round-trip.
- Defense-in-depth guards added to `simplify_locals`, `remove_unused_branches`, `optimize_added_constants` (others were already guarded in v0.4.0).
- `eliminate_dead_code` intentionally NOT guarded — it only deletes code after terminators, never reorders. Guarding it would defeat the pass.
- Dead `use_dataflow_env` branch removed; the unsafe path is gone, the safe path always uses the dataflow env.

## Regression tests

- `test_early_return_guard_prevents_store_hoist` — mirrors `gale_sem_count_take`, asserts `I32Eqz` appears before `I32Store` in optimized output. Without this PR: store at index 5, eqz at 7 (hoisted above guard). With this PR: original order preserved.
- `test_default_then_override_across_br_table_preserved` (from v0.4.0 PR-C) still passes.

## Test plan

- [x] cargo build --release passes
- [x] Both regression tests pass
- [x] All 244 unit tests pass
- [x] cargo clippy clean
- [x] Pre-commit hooks pass
- [ ] CI green

## v0.5.0 release sequence

| PR | Theme | Status |
|---|---|---|
| #88 | PR-A: VerificationResult strict mode + gale measurement | Open |
| **(this)** | **PR-B: hoist guard for Return/Br + CSE soundness fix** | Open |
| - | PR-C: Spec-feature corpus fixtures | Pending |
| - | PR-D: FusedOptimization.v in BUILD.bazel | Pending |
| - | PR-E: Tag v0.5.0 | Pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)