### PR TITLE
release/v0.5.0 PR-D: wire FusedOptimization.v into BUILD.bazel

### DIFF
--- a/proofs/BUILD.bazel
+++ b/proofs/BUILD.bazel
@@ -100,6 +100,25 @@ rocq_proof_test(
     deps = [":strength_reduction"],
 )
 
+# Fused/meld optimization proofs
+# Covers the optimization passes specific to WebAssembly modules produced by
+# component fusion: same-memory adapter collapse, adapter devirtualization,
+# trivial call elimination, type/import dedup, dead function elimination.
+rocq_library(
+    name = "fused_optimization",
+    srcs = ["simplify/FusedOptimization.v"],
+    deps = [
+        ":wasm_semantics",
+        ":term_semantics",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+rocq_proof_test(
+    name = "fused_optimization_test",
+    deps = [":fused_optimization"],
+)
+
 # =============================================================================
 # Master Correctness Theorem
 # =============================================================================
@@ -175,6 +194,7 @@ filegroup(
         ":identity",
         ":bitwise",
         ":strength_reduction",
+        ":fused_optimization",
     ],
     visibility = ["//visibility:public"],
 )
@@ -200,6 +220,7 @@ filegroup(
         ":identity",
         ":bitwise",
         ":strength_reduction",
+        ":fused_optimization",
         ":correctness",
         # Existing proofs
         ":stack_proofs",
@@ -226,6 +247,7 @@ test_suite(
         ":identity_test",
         ":bitwise_test",
         ":strength_reduction_test",
+        ":fused_optimization_test",
         ":correctness_test",
         ":stack_proofs_test",
         ":codec_proofs_test",


### PR DESCRIPTION
## Summary

Closes v0.4.0 audit D1: `proofs/simplify/FusedOptimization.v` was orphaned from the Bazel build, so CI never compiled or checked it. The file backs the fused/meld optimization pipeline with 7 axioms + 8+ theorems (same-memory adapter collapse, adapter devirtualization, trivial-call elimination, type/import dedup).

## What ships

- New `rocq_library` "fused_optimization" depending on `wasm_semantics` and `term_semantics`.
- New `rocq_proof_test` "fused_optimization_test".
- Added to the `all_proofs_test` test_suite.

## What's NOT in this PR (intentionally)

The 7 axioms in FusedOptimization.v remain. They are stated assumptions backing the fused-pipeline correctness theorems and need proper discharge against `WasmSemantics.v` operational semantics. That is non-trivial Rocq work — out of v0.5.0 scope. With this PR, at least the file compiles and the axioms are visible in CI.

## CI note

The "Rocq Formal Proofs" CI job is currently `continue-on-error: true` due to a known `rules_rocq_rust` toolchain linker error (`LLVM-19-rust-1.85.0-nightly` missing in the build environment). That is infra, not a proof regression. Once the toolchain is fixed, `FusedOptimization.v` will be checked alongside the other proofs.

## v0.5.0 release sequence

| PR | Theme | Status |
|---|---|---|
| #88 | PR-A: VerificationResult strict mode + gale measurement | Open |
| #89 | PR-B: hoist guard for Return/Br + CSE soundness fix | Open |
| #90 | PR-C: spec-feature corpus fixtures | Open |
| **(this)** | **PR-D: FusedOptimization.v in BUILD.bazel** | Open |
| - | PR-E: Tag v0.5.0 | Pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)