### PR TITLE
chore(ci): add concurrency control to all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -3,6 +3,10 @@
 
 name: Fuzzing
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 on:
   schedule:
     # Run nightly at 2am UTC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   release:
     types: [published]

--- a/.github/workflows/validate-shared.yml
+++ b/.github/workflows/validate-shared.yml
@@ -1,5 +1,9 @@
 name: Validate Shared Architecture
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [ main, develop, claude/** ]


### PR DESCRIPTION
## Summary

Closes the org-wide CI queue backlog issue per the cross-repo concurrency hardening brief. LOOM had 20 of ~93 jobs perpetually queued as of 2026-05-02 and a 0% pass rate on the queue tail — strong signal of retry-loop pressure from agents pushing rapid follow-up commits.

Without concurrency control, every push to a PR branch starts a fresh run while previous runs on superseded commits keep executing. With this PR, superseded PR runs are cancelled; runs on \`main\`, tags, releases, and scheduled events are never cancelled.

## Per-file classification

| File | Variant | Rationale |
|---|---|---|
| \`ci.yml\` | default | PR feedback workflow, safe to cancel superseded runs |
| \`validate-shared.yml\` | default | Same as ci.yml |
| \`release.yml\` | release (\`cancel-in-progress: false\`, group: \`release-<ref>\`) | A cancelled release mid-publish would leave registries / tags / attestations in inconsistent state |
| \`fuzz.yml\` | scheduled (group: \`<workflow>-<run_id>\`, \`cancel-in-progress: false\`) | Each nightly run is independent data and must complete |

## Diff

\`\`\`
.github/workflows/ci.yml              | 4 ++++
.github/workflows/fuzz.yml            | 4 ++++
.github/workflows/release.yml         | 4 ++++
.github/workflows/validate-shared.yml | 4 ++++
4 files changed, 16 insertions(+)
\`\`\`

Scope strictly \`.github/workflows/\`. No job-level concurrency, no \`runs-on:\` changes, no cache or permission tweaks.

## Verification

- [x] All 4 files parse cleanly via \`python3 yaml.safe_load_all\`.
- [x] Diff is exactly +16 lines (4 per file).
- [ ] CI green.
- [ ] Push a no-op follow-up commit and confirm earlier PR run shows as Cancelled in Actions UI within ~30s. (Will do after CI green.)

## Out of scope (separate work)

- Self-hosted runner migration
- Job parallelization / matrix restructuring
- Cache strategy changes
- Permission minimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)