### PR TITLE
ci: migrate workflows to smithy self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   rivet-validate:
     name: Rivet Artifact Traceability
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -35,7 +35,7 @@ jobs:
 
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -46,6 +46,8 @@ jobs:
 
   clippy:
     name: Clippy
+    # Stays on ubuntu-latest: requires `sudo apt-get install z3`; Z3 is not
+    # provisioned on smithy hosts. Migrate once smithy ships z3 in toolchains.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +64,7 @@ jobs:
 
   test:
     name: Test
+    # Stays on ubuntu-latest: matrix spans macOS + Windows; smithy is Linux-only.
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -76,6 +79,7 @@ jobs:
 
   build:
     name: Build
+    # Stays on ubuntu-latest: matrix spans macOS + Windows; smithy is Linux-only.
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -96,7 +100,7 @@ jobs:
 
   validate:
     name: Validate WebAssembly Output
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -165,6 +169,9 @@ jobs:
 
   coverage:
     name: Code Coverage
+    # Stays on ubuntu-latest: uses `sudo rm -rf` to free disk space on the
+    # GitHub-hosted image. Could migrate by dropping the free-disk step
+    # (smithy has plenty of disk via lv_runners) but leaving as-is for now.
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
@@ -192,7 +199,7 @@ jobs:
 
   benchmark:
     name: Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -206,6 +213,8 @@ jobs:
 
   verify:
     name: Z3 Verification Build
+    # Stays on ubuntu-latest: requires `sudo apt-get install z3`; Z3 is not
+    # provisioned on smithy hosts. Migrate once smithy ships z3.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -264,6 +273,8 @@ jobs:
 
   wasm-build:
     name: WASM Build (wasm32-wasip2 with Z3)
+    # Stays on ubuntu-latest: installs wasi-sdk into /opt with sudo mkdir/tar.
+    # Could migrate by extracting into $HOME, but skipping until needed.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -302,7 +313,7 @@ jobs:
 
   self-optimization:
     name: Self-Optimization Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     needs: [build, wasm-build]
     steps:
       - uses: actions/checkout@v4
@@ -349,6 +360,8 @@ jobs:
 
   rocq-proofs:
     name: Rocq Formal Proofs
+    # Stays on ubuntu-latest: requires Nix + Bazel; both are out-of-scope for
+    # smithy phase 1 (see migration playbook "What's currently out of scope").
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -370,6 +383,8 @@ jobs:
 
   differential:
     name: Differential Testing (vs wasm-opt)
+    # Stays on ubuntu-latest: requires `sudo apt-get install binaryen`;
+    # binaryen/wasm-opt is not provisioned on smithy hosts.
     runs-on: ubuntu-latest
     needs: [build]
     steps:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   fuzz:
     name: Fuzz ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     strategy:
       fail-fast: false
       matrix:
@@ -105,7 +105,7 @@ jobs:
 
   coverage:
     name: Fuzzing coverage report
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     needs: fuzz
     if: always()
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   build-native:
     name: Build Native (${{ matrix.os }})
+    # Stays on ubuntu-latest: matrix spans macOS + Windows; smithy is Linux-only.
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -75,6 +76,7 @@ jobs:
 
   build-wasm:
     name: Build WASM (wasm32-wasip2)
+    # Stays on ubuntu-latest: installs wasi-sdk into /opt with sudo mkdir/tar.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -110,6 +112,8 @@ jobs:
   release:
     name: Create Release
     needs: [build-native, build-wasm]
+    # Stays on ubuntu-latest: uses `sudo mv` for oras install plus Cosign
+    # OIDC keyless signing tied to GitHub-hosted runner identity.
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/validate-shared.yml
+++ b/.github/workflows/validate-shared.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test-shared:
     name: Test loom-shared
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
 
     steps:
       - name: Checkout code
@@ -56,7 +56,7 @@ jobs:
 
   test-workspace:
     name: Test Full Workspace
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     needs: test-shared
 
     steps:
@@ -100,7 +100,7 @@ jobs:
 
   integration-test:
     name: Integration Testing
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     needs: test-workspace
 
     steps:
@@ -149,7 +149,7 @@ jobs:
 
   check-api-stability:
     name: Check API Stability
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
 
     steps:
       - name: Checkout code
@@ -172,6 +172,8 @@ jobs:
 
   format-and-lint:
     name: Format and Lint
+    # Stays on ubuntu-latest: clippy step requires `sudo apt-get install z3`;
+    # Z3 is not provisioned on smithy hosts.
     runs-on: ubuntu-latest
 
     steps:
@@ -196,7 +198,7 @@ jobs:
 
   verify-architecture:
     name: Verify Architecture
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Migrates 12 of 24 GitHub Actions jobs across `ci.yml`, `fuzz.yml`, `release.yml`, and `validate-shared.yml` from GitHub-hosted runners to the [smithy](https://github.com/pulseengine/smithy) self-hosted fleet (`hetzner-private` runner group on `pulseengine-ci-01`). Follows the [migration playbook](https://github.com/pulseengine/smithy/blob/main/docs/migration-playbook.md) and matches the patterns landed in pulseengine/spar#201, pulseengine/rivet#262, pulseengine/kiln#247, and pulseengine/gale#35.

## Coverage

| Class | Count | Jobs |
|---|---|---|
| `rust-cpu` (12 G) | 9 | `rivet-validate`, `validate`, `benchmark`, `self-optimization` (ci.yml); `fuzz` (fuzz.yml); `test-shared`, `test-workspace`, `integration-test`, `check-api-stability` (validate-shared.yml) |
| `light` (4 G) | 3 | `format` (ci.yml); `coverage` (fuzz.yml); `verify-architecture` (validate-shared.yml) |
| `lean-mem` (24 G) | 0 | — |

## Stays on hosted

| Job | File | Reason |
|---|---|---|
| `clippy` | ci.yml | `sudo apt-get install z3` — Z3 not on smithy |
| `test` | ci.yml | matrix spans macOS + Windows |
| `build` | ci.yml | matrix spans macOS + Windows |
| `coverage` | ci.yml | `sudo rm -rf` to free disk |
| `verify` | ci.yml | `sudo apt-get install z3` |
| `wasm-build` | ci.yml | `sudo mkdir`/`tar` to install wasi-sdk into `/opt` |
| `rocq-proofs` | ci.yml | Nix + Bazel (out of scope per playbook) |
| `differential` | ci.yml | `sudo apt-get install binaryen` |
| `build-native` | release.yml | matrix spans macOS + Windows |
| `build-wasm` | release.yml | sudo for wasi-sdk install |
| `release` | release.yml | `sudo mv` for `oras` + Cosign keyless OIDC tied to GitHub-hosted identity |
| `format-and-lint` | validate-shared.yml | `sudo apt-get install z3` |

Each kept-hosted `runs-on:` has a one-line comment naming the reason.

## Workarounds applied

None new — every migrated job is a clean one-line `runs-on:` change. The repo doesn't currently use `EmbarkStudios/cargo-deny-action`, `rustsec/audit-check`, or `obi1kenobi/cargo-semver-checks-action`, so the playbook's documented action-replacement workarounds aren't needed here. The existing `cargo-semver-checks` step in `validate-shared.yml` already uses direct `cargo install` + invocation, which works on smithy as-is.

## Follow-ups (out of scope here)

- If smithy ships `z3` and `binaryen` in toolchains, four more jobs (`clippy`, `verify`, `differential`, `format-and-lint`) become trivially migratable.
- If we rewrite the wasi-sdk install to extract under `$HOME` instead of `/opt`, `wasm-build` (ci.yml + release.yml) becomes migratable too.

## Test plan

- [ ] All migrated jobs land on `rust-cpu` / `light` runners and complete green
- [ ] Hosted jobs (`test`, `build`, etc.) still run on GitHub-hosted as before
- [ ] No changes to artifact uploads / release flow
- [ ] Compile cache primes on first run; second push is faster on the same branch

## Rollback

Revert this commit. All `runs-on:` flips back to `ubuntu-latest` and the next run uses GitHub-hosted compute.