### PR TITLE
release: v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bump workspace version 0.5.0 → 0.6.0.

This release is driven entirely by real-world findings on production gale code (Verus-verified kernel-scheduler FFI wasm): closing v0.5.0's +6.3% CSE size regression, lifting two early-exit guards that made LOOM a no-op on kernel-style code, and fixing a Z3 panic that blocked the inline pass on i64-heavy modules.

## Merged PRs

| PR | Title |
|---|---|
| #94 | fix(cse): cost-aware dedup gate eliminates gale +6.3% regression |
| #95 | feat(opt): eliminate_dead_locals — drop write-only locals (-0.86% on gale) |
| #96 | feat(opt): eliminate_dead_stores — full backward liveness on structured wasm |
| #99 | fix(verify): correct i64 local widths in Z3 encoder + vacuum const+drop peephole (closes #98) |

## Measured impact

**gale_ffi (1.9 KB kernel FFI):**

| Build | Code section | Δ vs baseline |
|---|---|---|
| baseline | 811 B | — |
| v0.5.0 (regression) | 862 B | +6.3% |
| **v0.6.0** | **804 B** | **-0.86%** |

A 6.7-point swing on real kernel-scheduler code.

**calculator.wasm (2.3 MB component):**
- `--passes dead-stores` alone: 2,337,724 → 2,327,794 bytes (-0.4%, ~10 KB)

## Test count

247 → 317 tests (+70 across all v0.6.0 PRs)

## CHANGELOG

Detailed v0.6.0 entry already in `CHANGELOG.md` (landed via #99).

## Notes

- Closes #98 (Z3 SortDiffers panic on i64-heavy wasm).
- The Rocq Formal Proofs CI job has been failing on `release/v0.6.0-pr-*` branches due to a Bazel external-repo fetch issue for `rocq_of_rust_source` — this is an upstream CI infrastructure issue and the job is configured `continue-on-error: true`. Not a v0.6.0 regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)