### PR TITLE
feat(opt): grow Souper rule set to 12 identities, wire into pipeline (v0.9.0 PR-L2)

### DIFF
--- a/loom-cli/src/main.rs
+++ b/loom-cli/src/main.rs
@@ -50,7 +50,7 @@ enum Commands {
         attestation: bool,
 
         /// Select specific optimization passes (comma-separated)
-        /// Available: inline,precompute,constant-folding,canonicalize,cse,advanced,branches,dce,merge-blocks,vacuum,simplify-locals,dead-stores,dead-locals,vacuum-final
+        /// Available: inline,precompute,constant-folding,canonicalize,peephole-synth,cse,advanced,branches,dce,merge-blocks,vacuum,simplify-locals,dead-stores,dead-locals,vacuum-final
         /// Example: --passes inline,constant-folding,dce
         /// Default: all passes
         #[arg(long, value_delimiter = ',')]
@@ -439,6 +439,19 @@ fn optimize_command(
         loom_core::optimize::canonicalize(&mut module).context("Canonicalize failed")?;
         let after = count_instructions(&module);
         track_pass("canonicalize", before, after);
+    }
+
+    // Souper-shaped peephole synthesis (PR-L2): hand-curated arithmetic
+    // identity rules (12 candidates). Runs AFTER canonicalize (so the
+    // canonical operand-order is in place) and BEFORE cse (so the
+    // identity-eliminated forms feed CSE's value-numbering).
+    if should_run("peephole-synth") {
+        println!("  Running: peephole-synth");
+        let before = count_instructions(&module);
+        loom_core::peephole_synth::apply_peephole_synth(&mut module)
+            .context("Peephole synthesis failed")?;
+        let after = count_instructions(&module);
+        track_pass("peephole-synth", before, after);
     }
 
     if should_run("cse") {

--- a/loom-core/src/peephole_synth.rs
+++ b/loom-core/src/peephole_synth.rs
@@ -1,11 +1,10 @@
-//! Peephole synthesis (Souper-shaped MVP, v0.8.0 PR-L).
+//! Peephole synthesis (Souper-shaped, v0.9.0 PR-L2).
 //!
-//! Minimal first cut of the algorithmic-solver direction from
+//! Hand-curated extension of the algorithmic-solver direction from
 //! `docs/research/v0.7.0/algorithmic-solver-feasibility.md`. The full
-//! Souper analog is ~1500 LOC; this PR ships the harness with 3
-//! hand-curated arithmetic-identity rules so the infrastructure exists
-//! for future PRs to grow the candidate set without touching the
-//! pipeline integration.
+//! Souper analog is ~1500 LOC; PR-L shipped the harness with 3 rules,
+//! PR-L2 grows the set to 12 hand-proven arithmetic identities and
+//! wires the pass into the optimizer pipeline.
 //!
 //! ## What's here
 //!
@@ -15,31 +14,55 @@
 //!   - A formal-proof comment documenting WHY the rule is sound.
 //!
 //! The `apply_peephole_synth` pass walks each function and replaces
-//! each match. The existing per-function Z3 translation validator
-//! (used by `vacuum`, `simplify_locals`, etc.) wraps the call site
-//! so unsound rules would be caught even if a candidate sneaks
-//! through. That's the safety net.
+//! each match. The existing per-function stack validator wraps the
+//! call site so any rewrite that breaks stack typing is caught and
+//! reverted. The candidates themselves are right-identity patterns
+//! whose `pattern` consumes `(stack-top: const, below: x)` and leaves
+//! `x` on the stack, so the stack effect of `pattern` and `replacement`
+//! (empty) match by construction.
+//!
+//! ## Operand-order audit
+//!
+//! WebAssembly binary ops pop in reverse: for `iN.<op>`, the
+//! second-pushed operand `c2` is popped first, then `c1`, then the
+//! result `c1 op c2` is pushed. Every candidate below puts the
+//! constant on the stack-top (the position of `c2`), so:
+//!
+//!   - `x op 0`  for op ∈ {add, sub, or, shl, shr_s, shr_u}: identity in x
+//!   - `x op 1`  for op = mul: identity in x
+//!   - `x & -1`: identity in x (all-ones AND)
+//!
+//! Note: `0 - x` (= -x) is NOT folded — that would require the constant
+//! on the bottom of the stack, not the top.
 //!
 //! ## Why no runtime Z3 gate
 //!
-//! The full Souper design includes a startup-time Z3 verifier that
-//! re-checks every candidate before the optimizer runs. For the 3
-//! hand-curated identities in this PR, that's overkill — the proofs
-//! are well-known algebraic identities and the per-function validator
-//! at the consumer site provides the same guarantee at runtime cost
-//! that's lower than running Z3 setup on every module load. A
-//! follow-up PR-L2 will add the startup gate once the candidate set
-//! grows past what can be hand-audited.
+//! For the 12 hand-curated identities in this PR, the proofs are
+//! well-known algebraic identities. A future PR will add the
+//! startup-time Z3 verifier once the candidate set grows past what
+//! can be hand-audited (e.g., once we start harvesting from real
+//! corpora).
 //!
 //! ## Candidates shipped
 //!
-//! All three are RIGHT-IDENTITY arithmetic rewrites: the const operand
-//! is on the stack-top, the other operand is just below. They take
-//! the form `<x> ; iN.const I ; iN.op` → `<x>`.
+//! All twelve are RIGHT-IDENTITY arithmetic rewrites. They take the
+//! form `<x> ; iN.const I ; iN.op` → `<x>`.
 //!
-//!   1. `<x> ; i32.const 0 ; i32.add`  →  `<x>`     (x + 0 = x)
-//!   2. `<x> ; i32.const 0 ; i32.or`   →  `<x>`     (x | 0 = x)
-//!   3. `<x> ; i32.const -1 ; i32.and` →  `<x>`     (x & -1 = x, since -1 is all-ones in two's complement)
+//! i32:
+//!   1. `<x> ; i32.const 0  ; i32.add`    →  `<x>`   (x + 0 = x)
+//!   2. `<x> ; i32.const 0  ; i32.or`     →  `<x>`   (x | 0 = x)
+//!   3. `<x> ; i32.const -1 ; i32.and`    →  `<x>`   (x & -1 = x)
+//!   4. `<x> ; i32.const 1  ; i32.mul`    →  `<x>`   (x * 1 = x)
+//!   5. `<x> ; i32.const 0  ; i32.sub`    →  `<x>`   (x - 0 = x)
+//!   6. `<x> ; i32.const 0  ; i32.shl`    →  `<x>`   (x << 0 = x)
+//!   7. `<x> ; i32.const 0  ; i32.shr_s`  →  `<x>`   (x >>s 0 = x)
+//!   8. `<x> ; i32.const 0  ; i32.shr_u`  →  `<x>`   (x >>u 0 = x)
+//!
+//! i64:
+//!   9. `<x> ; i64.const 0  ; i64.add`    →  `<x>`   (x + 0 = x)
+//!  10. `<x> ; i64.const 0  ; i64.or`     →  `<x>`   (x | 0 = x)
+//!  11. `<x> ; i64.const -1 ; i64.and`    →  `<x>`   (x & -1 = x)
+//!  12. `<x> ; i64.const 1  ; i64.mul`    →  `<x>`   (x * 1 = x)
 //!
 //! Proofs are documented per-candidate below.
 
@@ -51,7 +74,7 @@ use anyhow::Result;
 /// reordering, no cross-block reach).
 struct Candidate {
     /// Human-readable name (used in revert telemetry — currently unread,
-    /// but reserved for the L2 startup gate that will log per-rule
+    /// but reserved for a future startup gate that will log per-rule
     /// admission events).
     #[allow(dead_code)]
     name: &'static str,
@@ -67,6 +90,7 @@ struct Candidate {
 /// no-op for the right-hand operand. The `replacement` (empty here)
 /// achieves the same identity at zero cost.
 const CANDIDATES: &[Candidate] = &[
+    // ─── i32 ────────────────────────────────────────────────────────────
     Candidate {
         name: "i32_add_zero_identity",
         // Proof: ∀x: BV32. x + 0 = x (additive identity in Z/2^32).
@@ -90,12 +114,90 @@ const CANDIDATES: &[Candidate] = &[
         pattern: &[Instruction::I32Const(-1), Instruction::I32And],
         replacement: &[],
     },
+    Candidate {
+        name: "i32_mul_one_identity",
+        // Proof: ∀x: BV32. x * 1 = x (multiplicative identity in Z/2^32).
+        // wasm i32.mul is two's-complement multiplication mod 2^32, for
+        // which 1 is the unique multiplicative identity.
+        pattern: &[Instruction::I32Const(1), Instruction::I32Mul],
+        replacement: &[],
+    },
+    Candidate {
+        name: "i32_sub_zero_identity",
+        // Proof: ∀x: BV32. x - 0 = x.
+        // Operand-order check: wasm pops c2 (top) then c1 (below), and
+        // pushes c1 - c2. With c2 = 0, the result is c1 = x. Note this
+        // is the RIGHT-zero subtraction; 0 - x = -x is NOT folded.
+        pattern: &[Instruction::I32Const(0), Instruction::I32Sub],
+        replacement: &[],
+    },
+    Candidate {
+        name: "i32_shl_zero_identity",
+        // Proof: ∀x: BV32. x << 0 = x.
+        // wasm i32.shl is defined as `c1 << (c2 mod 32)`. With c2 = 0,
+        // the shift amount is 0, and shifting by 0 is the identity.
+        // (For c2 = 32 the shift would also be 0 by the mod rule, but
+        // we do NOT fold that case — only the literal constant 0 is
+        // guaranteed to be the shift-by-0 we want.)
+        pattern: &[Instruction::I32Const(0), Instruction::I32Shl],
+        replacement: &[],
+    },
+    Candidate {
+        name: "i32_shr_s_zero_identity",
+        // Proof: ∀x: BV32. x >>s 0 = x.
+        // wasm i32.shr_s is arithmetic right shift by (c2 mod 32). With
+        // c2 = 0, the shift amount is 0; arithmetic shift by 0 yields
+        // x unchanged (sign bit is replicated zero times).
+        pattern: &[Instruction::I32Const(0), Instruction::I32ShrS],
+        replacement: &[],
+    },
+    Candidate {
+        name: "i32_shr_u_zero_identity",
+        // Proof: ∀x: BV32. x >>u 0 = x.
+        // wasm i32.shr_u is logical right shift by (c2 mod 32). With
+        // c2 = 0, the shift amount is 0; logical shift by 0 yields x
+        // unchanged (no bits are dropped or zero-extended).
+        pattern: &[Instruction::I32Const(0), Instruction::I32ShrU],
+        replacement: &[],
+    },
+    // ─── i64 ────────────────────────────────────────────────────────────
+    Candidate {
+        name: "i64_add_zero_identity",
+        // Proof: ∀x: BV64. x + 0 = x (additive identity in Z/2^64).
+        // wasm i64.add is two's-complement addition mod 2^64, for which
+        // 0 is the unique additive identity.
+        pattern: &[Instruction::I64Const(0), Instruction::I64Add],
+        replacement: &[],
+    },
+    Candidate {
+        name: "i64_or_zero_identity",
+        // Proof: ∀x: BV64. x | 0 = x (bitwise-OR identity element is 0).
+        // Trivially true bit-by-bit on 64 bits.
+        pattern: &[Instruction::I64Const(0), Instruction::I64Or],
+        replacement: &[],
+    },
+    Candidate {
+        name: "i64_and_neg_one_identity",
+        // Proof: ∀x: BV64. x & 0xFFFFFFFFFFFFFFFF = x (bitwise-AND
+        // identity element is all-ones). In two's-complement i64,
+        // -1 = 0xFFFFFFFFFFFFFFFF. Bit-by-bit on 64 bits.
+        pattern: &[Instruction::I64Const(-1), Instruction::I64And],
+        replacement: &[],
+    },
+    Candidate {
+        name: "i64_mul_one_identity",
+        // Proof: ∀x: BV64. x * 1 = x (multiplicative identity in Z/2^64).
+        // wasm i64.mul is two's-complement multiplication mod 2^64, for
+        // which 1 is the unique multiplicative identity.
+        pattern: &[Instruction::I64Const(1), Instruction::I64Mul],
+        replacement: &[],
+    },
 ];
 
 /// Apply all shipped peephole candidates to every function in the
-/// module. Uses the existing per-function Z3 translation validator
-/// as a safety net: if any rewrite changes observable semantics,
-/// the validator rejects and reverts.
+/// module. Uses the existing per-function stack validator as a safety
+/// net: if any rewrite somehow changes stack typing, the validator
+/// rejects and reverts.
 pub fn apply_peephole_synth(module: &mut Module) -> Result<usize> {
     let mut total_folds = 0;
 
@@ -105,11 +207,9 @@ pub fn apply_peephole_synth(module: &mut Module) -> Result<usize> {
         total_folds += folds;
 
         // No Z3 hook for this MVP — the candidates are hand-proven
-        // identity rules and the existing translation validator (run
-        // by adjacent passes like vacuum) will catch any byte-level
-        // divergence. A future PR-L2 will run TranslationValidator
-        // here directly, but for now we trust the rules + the
-        // downstream validators.
+        // identity rules. The existing stack validator catches any
+        // byte-level divergence. A future PR will run a startup-time
+        // Z3 gate here, but for now we trust the rules + the validator.
         if folds > 0 {
             // Quick sanity: the function body must still validate.
             // If for some reason it doesn't (e.g., a future rule
@@ -319,5 +419,321 @@ mod tests {
         let mut module = parse::parse_wat(wat).expect("parse");
         let folds = apply_peephole_synth(&mut module).expect("apply");
         assert_eq!(folds, 1, "block-nested identity must fold");
+    }
+
+    // ─── PR-L2: new candidate fire tests ──────────────────────────────
+
+    #[test]
+    fn test_i32_mul_one_identity() {
+        let wat = r#"(module
+            (func (export "test") (param i32) (result i32)
+                local.get 0
+                i32.const 1
+                i32.mul
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 1, "i32.mul 1 identity must fire");
+
+        let has_mul = module.functions[0]
+            .instructions
+            .iter()
+            .any(|i| matches!(i, Instruction::I32Mul));
+        assert!(!has_mul, "i32.mul must be gone after fold");
+    }
+
+    #[test]
+    fn test_i32_sub_zero_identity() {
+        // x - 0 = x. Operand-order check baked in: the const 0 is the
+        // RHS (top of stack), so this is the right-identity case.
+        let wat = r#"(module
+            (func (export "test") (param i32) (result i32)
+                local.get 0
+                i32.const 0
+                i32.sub
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 1, "i32.sub 0 identity must fire");
+
+        let has_sub = module.functions[0]
+            .instructions
+            .iter()
+            .any(|i| matches!(i, Instruction::I32Sub));
+        assert!(!has_sub, "i32.sub must be gone after fold");
+    }
+
+    #[test]
+    fn test_i32_shl_zero_identity() {
+        let wat = r#"(module
+            (func (export "test") (param i32) (result i32)
+                local.get 0
+                i32.const 0
+                i32.shl
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 1, "i32.shl 0 identity must fire");
+
+        let has_shl = module.functions[0]
+            .instructions
+            .iter()
+            .any(|i| matches!(i, Instruction::I32Shl));
+        assert!(!has_shl, "i32.shl must be gone after fold");
+    }
+
+    #[test]
+    fn test_i32_shr_s_zero_identity() {
+        let wat = r#"(module
+            (func (export "test") (param i32) (result i32)
+                local.get 0
+                i32.const 0
+                i32.shr_s
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 1, "i32.shr_s 0 identity must fire");
+
+        let has_shr = module.functions[0]
+            .instructions
+            .iter()
+            .any(|i| matches!(i, Instruction::I32ShrS));
+        assert!(!has_shr, "i32.shr_s must be gone after fold");
+    }
+
+    #[test]
+    fn test_i32_shr_u_zero_identity() {
+        let wat = r#"(module
+            (func (export "test") (param i32) (result i32)
+                local.get 0
+                i32.const 0
+                i32.shr_u
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 1, "i32.shr_u 0 identity must fire");
+
+        let has_shr = module.functions[0]
+            .instructions
+            .iter()
+            .any(|i| matches!(i, Instruction::I32ShrU));
+        assert!(!has_shr, "i32.shr_u must be gone after fold");
+    }
+
+    #[test]
+    fn test_i64_add_zero_identity() {
+        let wat = r#"(module
+            (func (export "test") (param i64) (result i64)
+                local.get 0
+                i64.const 0
+                i64.add
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 1, "i64.add 0 identity must fire");
+
+        let has_add = module.functions[0]
+            .instructions
+            .iter()
+            .any(|i| matches!(i, Instruction::I64Add));
+        assert!(!has_add, "i64.add must be gone after fold");
+    }
+
+    #[test]
+    fn test_i64_or_zero_identity() {
+        let wat = r#"(module
+            (func (export "test") (param i64) (result i64)
+                local.get 0
+                i64.const 0
+                i64.or
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 1, "i64.or 0 identity must fire");
+
+        let has_or = module.functions[0]
+            .instructions
+            .iter()
+            .any(|i| matches!(i, Instruction::I64Or));
+        assert!(!has_or, "i64.or must be gone after fold");
+    }
+
+    #[test]
+    fn test_i64_and_neg_one_identity() {
+        let wat = r#"(module
+            (func (export "test") (param i64) (result i64)
+                local.get 0
+                i64.const -1
+                i64.and
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 1, "i64.and -1 identity must fire");
+
+        let has_and = module.functions[0]
+            .instructions
+            .iter()
+            .any(|i| matches!(i, Instruction::I64And));
+        assert!(!has_and, "i64.and must be gone after fold");
+    }
+
+    #[test]
+    fn test_i64_mul_one_identity() {
+        let wat = r#"(module
+            (func (export "test") (param i64) (result i64)
+                local.get 0
+                i64.const 1
+                i64.mul
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 1, "i64.mul 1 identity must fire");
+
+        let has_mul = module.functions[0]
+            .instructions
+            .iter()
+            .any(|i| matches!(i, Instruction::I64Mul));
+        assert!(!has_mul, "i64.mul must be gone after fold");
+    }
+
+    // ─── PR-L2: negative cases (constant must be the identity element) ──
+
+    #[test]
+    fn test_does_not_fold_mul_non_one() {
+        // x * 2 must NOT fold — 2 is not the multiplicative identity.
+        let wat = r#"(module
+            (func (export "test") (param i32) (result i32)
+                local.get 0
+                i32.const 2
+                i32.mul
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 0, "i32.mul 2 must NOT fold");
+    }
+
+    #[test]
+    fn test_does_not_fold_sub_nonzero() {
+        // x - 1 must NOT fold.
+        let wat = r#"(module
+            (func (export "test") (param i32) (result i32)
+                local.get 0
+                i32.const 1
+                i32.sub
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 0, "i32.sub 1 must NOT fold");
+    }
+
+    #[test]
+    fn test_does_not_fold_shl_nonzero() {
+        // x << 1 must NOT fold (it doubles x).
+        let wat = r#"(module
+            (func (export "test") (param i32) (result i32)
+                local.get 0
+                i32.const 1
+                i32.shl
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 0, "i32.shl 1 must NOT fold");
+    }
+
+    #[test]
+    fn test_does_not_fold_shr_s_nonzero() {
+        let wat = r#"(module
+            (func (export "test") (param i32) (result i32)
+                local.get 0
+                i32.const 1
+                i32.shr_s
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 0, "i32.shr_s 1 must NOT fold");
+    }
+
+    #[test]
+    fn test_does_not_fold_shr_u_nonzero() {
+        let wat = r#"(module
+            (func (export "test") (param i32) (result i32)
+                local.get 0
+                i32.const 1
+                i32.shr_u
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 0, "i32.shr_u 1 must NOT fold");
+    }
+
+    #[test]
+    fn test_does_not_fold_i64_add_nonzero() {
+        let wat = r#"(module
+            (func (export "test") (param i64) (result i64)
+                local.get 0
+                i64.const 1
+                i64.add
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 0, "i64.add 1 must NOT fold");
+    }
+
+    #[test]
+    fn test_does_not_fold_i64_or_nonzero() {
+        let wat = r#"(module
+            (func (export "test") (param i64) (result i64)
+                local.get 0
+                i64.const 1
+                i64.or
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 0, "i64.or 1 must NOT fold");
+    }
+
+    #[test]
+    fn test_does_not_fold_i64_and_non_neg_one() {
+        // x & 0 = 0, NOT x — must not fold.
+        let wat = r#"(module
+            (func (export "test") (param i64) (result i64)
+                local.get 0
+                i64.const 0
+                i64.and
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 0, "i64.and 0 must NOT fold (it's x & 0 = 0, not identity)");
+    }
+
+    #[test]
+    fn test_does_not_fold_i64_mul_non_one() {
+        let wat = r#"(module
+            (func (export "test") (param i64) (result i64)
+                local.get 0
+                i64.const 2
+                i64.mul
+            )
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        let folds = apply_peephole_synth(&mut module).expect("apply");
+        assert_eq!(folds, 0, "i64.mul 2 must NOT fold");
     }
 }


### PR DESCRIPTION
## Summary

Grows the peephole-synth candidate set from 3 (PR-L) to **12 hand-curated arithmetic identity rules**, each with a documented one-line algebraic proof. Also wires the pass into the optimizer pipeline (PR-L shipped the module but didn't register it as a CLI pass — discovered during measurement).

## New candidates (9 added)

| Rule | Proof |
|---|---|
| `<x>; i32.const 1; i32.mul → <x>` | ∀x: BV32. x · 1 = x (multiplicative identity in Z/2³²) |
| `<x>; i32.const 0; i32.sub → <x>` | x − 0 = x; operand order audited (wasm pops c2 then c1, pushes c1 − c2; const is c2) |
| `<x>; i32.const 0; i32.shl → <x>` | x ≪ 0 = x (wasm: shift count is c2 mod 32; 0 mod 32 = 0) |
| `<x>; i32.const 0; i32.shr_s → <x>` | x ≫ₛ 0 = x (arithmetic right shift by 0 is no-op) |
| `<x>; i32.const 0; i32.shr_u → <x>` | x ≫ᵤ 0 = x (logical right shift by 0 is no-op) |
| `<x>; i64.const 0; i64.add → <x>` | x + 0 = x (additive identity in Z/2⁶⁴) |
| `<x>; i64.const 0; i64.or → <x>` | x \| 0 = x (OR identity is 0 bit-by-bit) |
| `<x>; i64.const -1; i64.and → <x>` | x & −1 = x (−1 = 0xFFFFFFFFFFFFFFFF in two's-complement i64) |
| `<x>; i64.const 1; i64.mul → <x>` | x · 1 = x (multiplicative identity in Z/2⁶⁴) |

## Pipeline wiring (discovered gap)

PR-L (v0.8.0) shipped the module but DID NOT register the pass with the CLI optimizer. Confirmed via `loom optimize --stats` that the pass never ran in production. This PR registers `peephole-synth` between `canonicalize` and `cse` — canonical forms feed peephole reductions, peephole reductions feed CSE.

## Tests (18 new)

9 fire tests (identity must fold) + 9 negative tests (non-identity constant must NOT fold). Same shape as PR-L's existing 6 tests. Total `peephole_synth::` tests: 24 (was 6).

## Soundness audits skipped/deferred

- `i32.eqz; i32.eqz` (boolean-normalize): no useful no-op replacement form available with the single-shape pattern model.
- `<x>; <x>; i32.eq → 1`: requires duplicate-operand detection / value numbering — out of scope.
- Power-of-2 mul/div → shift: needs overflow-guard reasoning (especially for signed div) — deferred to PR-L3.
- `i32.const C; i32.shl` for C ≥ 32: spec-defined behavior (C mod width), but only literal-zero folded to avoid encoding-dependent surprises.

## Measurement

Gale byte delta: zero. Gale's wasm doesn't contain trivial identity patterns (rustc folded them at compile time). The wins land on hand-written wasm and on source languages that don't fold at compile time. Confirmed peephole-synth pass appears in the `--stats` per-pass breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)