### PR TITLE
feat(verify): verified memory-reading inlining — gale flight_control seam (closes #155, v1.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to LOOM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2026-06-02
+
+**Optimization release: verified inlining of memory-reading callees (#155).**
+Delivers the gale `flight_control` seam — inlining `controller_step` (which
+reads the `flight_state` a preceding `filter_step` call left in memory) into
+its caller, *proven* by the Z3 translation validator. General, not
+gale-specific; verified bit-for-bit against gale's native oracle.
+
+### Added / Changed
+
+- **Memory-through inline verification.** The by-body inline modeler now
+  threads the caller's shared memory `Array` and encodes full-width
+  `i32`/`i64` loads via helpers (`encode_i32_load_from` / `encode_i64_load_from`)
+  **factored from and shared with the main encoder** — so the original's
+  modeled `call F` and the optimized's inlined body produce bit-identical Z3
+  expressions. Aliasing/read-sees-write is sound by construction in loom's
+  single linear-memory `Array` model. The inline whitelist
+  (`is_inline_modelable_instr`) gains full-width loads; stores, globals,
+  partial-width loads, control flow and calls stay out (conservative).
+- **Deterministic havoc naming.** Impure-call havoc now uses a per-encode
+  counter instead of a global static, so the Nth impure call gets the same
+  symbolic memory/global name in the original and optimized encodings (they
+  unify in Z3). Required whenever a result depends on post-impure-call state —
+  e.g. a reader inlined after an opaque (havoc'd) writer call.
+- **Writer callees are not inlined.** A callee that writes memory/globals is
+  excluded from inlining: the validator models a *remaining* call's effects as
+  a havoc, which an *inlined* writer's concrete stores would not match once
+  observed downstream — producing a false counterexample. Keeping writers as
+  opaque calls (with deterministic havoc) lets a following reader's inline be
+  proven against the same havoc'd state. By-body store modeling is future work.
+- **Single-call-site inline budget** raised (200 vs 50 instructions): a
+  single-call-site callee is not duplicated, so a larger budget is profitable;
+  it stays well under the Z3 verify cap so inlines remain verified.
+
+### Validation
+
+- New soundness guard `test_inline_verifier_proves_and_rejects_memory_load_inline`
+  (proves a correct `i32.load` inline, rejects a wrong-offset one) and
+  `test_inline_memory_seam_reader_inlined_writer_kept` (reader inlined, writer
+  kept). 389 lib tests pass.
+- gale's minimal `min_seam` oracle matches the native reference bit-for-bit
+  (`seam(_,v) = clamp(v + (v>>1), -127, 127)`); the drive-free `flight_seam`
+  module inlines `controller_step` proven (no revert), valid output.
+- The 7 pre-existing LICM/DCE integration failures (#155→#150) are unchanged.
+
 ## [1.1.5] - 2026-05-30
 
 **Bug-fix release: inline a local callee even when the caller also calls

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.5"
+version = "1.1.6"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -13283,6 +13283,27 @@ pub mod optimize {
                 if *func_idx < num_imported_funcs {
                     continue;
                 }
+                // loom#155: do NOT inline a callee that WRITES memory/globals.
+                // The translation validator models a *remaining* call's effects
+                // as a havoc (fresh symbolic state), but an *inlined* writer
+                // performs concrete stores — so if any later code (e.g. an
+                // inlined reader, the gale filter_step→controller_step seam)
+                // observes that state, the original (havoc) and optimized
+                // (concrete) encodings diverge and the verifier reverts with a
+                // FALSE counterexample. By-body inline modeling is read-only
+                // (loom#155), so writers can't be proven yet: keep them as
+                // opaque calls (the deterministic havoc makes a following
+                // reader's inline provable against the SAME havoc'd state).
+                // This is exactly the gale ask: "filter_step can stay an opaque
+                // call; I only need controller_step inlined."
+                if let Some(callee) = module
+                    .functions
+                    .get((*func_idx - num_imported_funcs) as usize)
+                {
+                    if function_writes_state(callee) {
+                        continue;
+                    }
+                }
                 let size = function_sizes.get(func_idx).copied().unwrap_or(0);
 
                 // Heuristic: inline if:
@@ -13381,6 +13402,42 @@ pub mod optimize {
         }
 
         Ok(())
+    }
+
+    /// loom#155: does this function write observable state (linear memory or
+    /// globals)? Such callees are excluded from inlining because the
+    /// translation validator models a remaining call's effects as a havoc,
+    /// which an inlined writer's concrete stores would not match once observed
+    /// (see the candidate-loop comment). Recurses into control flow.
+    fn function_writes_state(func: &super::Function) -> bool {
+        fn body_writes(instrs: &[Instruction]) -> bool {
+            instrs.iter().any(|i| match i {
+                Instruction::I32Store { .. }
+                | Instruction::I64Store { .. }
+                | Instruction::F32Store { .. }
+                | Instruction::F64Store { .. }
+                | Instruction::I32Store8 { .. }
+                | Instruction::I32Store16 { .. }
+                | Instruction::I64Store8 { .. }
+                | Instruction::I64Store16 { .. }
+                | Instruction::I64Store32 { .. }
+                | Instruction::GlobalSet(_)
+                | Instruction::MemoryGrow(_)
+                | Instruction::MemoryFill(_)
+                | Instruction::MemoryCopy { .. }
+                | Instruction::MemoryInit { .. } => true,
+                Instruction::Block { body, .. } | Instruction::Loop { body, .. } => {
+                    body_writes(body)
+                }
+                Instruction::If {
+                    then_body,
+                    else_body,
+                    ..
+                } => body_writes(then_body) || body_writes(else_body),
+                _ => false,
+            })
+        }
+        body_writes(&func.instructions)
     }
 
     /// Inline function calls in a block of instructions
@@ -18485,6 +18542,79 @@ mod tests {
                 .expect("verify ok"),
             "SOUNDNESS: wrong memory-load inline (offset=4) must NOT verify against call getx",
         );
+    }
+
+    #[test]
+    fn test_inline_memory_seam_reader_inlined_writer_kept() {
+        // loom#155: the gale flight_control seam — `seam(s,v){ wr(s,v); return
+        // rd(s); }` where `wr` WRITES *s and `rd` READS it. loom must inline
+        // the reader `rd` (proven against the havoc'd memory left by the
+        // opaque `wr` call) while keeping `wr` as a call — inlining the writer
+        // would diverge (concrete stores vs the original's havoc) and falsely
+        // revert. Mirrors gale's min_seam; the verifier proves the kept inline.
+        let wat = r#"(module
+            (memory 1)
+            (func $seam (export "seam") (param i32 i32) (result i32)
+                local.get 0
+                local.get 1
+                call $wr
+                local.get 0
+                call $rd)
+            (func $rd (param i32) (result i32)
+                local.get 0
+                i32.load offset=4
+                local.get 0
+                i32.load
+                i32.add)
+            (func $wr (param i32 i32)
+                local.get 0
+                local.get 1
+                i32.store
+                local.get 0
+                local.get 1
+                i32.store offset=4)
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        // full idx: seam=0, rd=1, wr=2 (no imports).
+        let rd_before = module.functions[0]
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, Instruction::Call(1)))
+            .count();
+        let wr_before = module.functions[0]
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, Instruction::Call(2)))
+            .count();
+        assert_eq!(
+            (rd_before, wr_before),
+            (1, 1),
+            "seam starts with one rd + one wr call"
+        );
+
+        optimize::inline_functions(&mut module).expect("must not panic");
+
+        let seam = &module.functions[0];
+        let rd_after = seam
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, Instruction::Call(1)))
+            .count();
+        let wr_after = seam
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, Instruction::Call(2)))
+            .count();
+        assert_eq!(
+            rd_after, 0,
+            "memory-reading callee rd must be inlined (proven via memory-through modeling)"
+        );
+        assert_eq!(
+            wr_after, 1,
+            "memory-writing callee wr must NOT be inlined (kept as opaque havoc call)"
+        );
+        let wasm_bytes = encode::encode_wasm(&module).expect("encode");
+        wasmparser::validate(&wasm_bytes).expect("output validates");
     }
 
     #[test]

--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -13286,13 +13286,27 @@ pub mod optimize {
                 let size = function_sizes.get(func_idx).copied().unwrap_or(0);
 
                 // Heuristic: inline if:
-                // 1. Single call site, OR
-                // 2. Small function (< 10 instructions)
-                if call_count == 1 || size < 10 {
-                    // Don't inline large functions even if single call site
-                    if size < 50 {
-                        inline_candidates.push(*func_idx);
-                    }
+                // 1. Single call site — profitable: inlining removes the call
+                //    overhead and opens cross-function optimization (the gale
+                //    flight_control seam, #155). A single-call-site callee is
+                //    not duplicated, so a generous size budget is justified.
+                // 2. Small function (< 10 instructions) — cheap even when
+                //    called from multiple sites.
+                //
+                // SIZE_LIMIT stays well under the Z3 verify cap
+                // (LOOM_Z3_MAX_INSTRUCTIONS, default 2000) so the inlined
+                // function is still VERIFIED, never silently skipped — the
+                // translation validator remains the correctness gate, and the
+                // #147 fixpoint guard bounds total expansion.
+                const SINGLE_CALL_SITE_LIMIT: usize = 200;
+                const MULTI_CALL_SITE_LIMIT: usize = 50;
+                let limit = if call_count == 1 {
+                    SINGLE_CALL_SITE_LIMIT
+                } else {
+                    MULTI_CALL_SITE_LIMIT
+                };
+                if (call_count == 1 || size < 10) && size < limit {
+                    inline_candidates.push(*func_idx);
                 }
             }
 
@@ -18408,6 +18422,68 @@ mod tests {
             !verify_function_equivalence_with_context(&orig, &wrong, "test", &ctx)
                 .expect("verify ok"),
             "SOUNDNESS: wrong i64 inline (x+2) must NOT verify against call add1",
+        );
+    }
+
+    #[cfg(feature = "verification")]
+    #[test]
+    fn test_inline_verifier_proves_and_rejects_memory_load_inline() {
+        // loom#155 SOUNDNESS GUARD for memory-through inline modeling.
+        // `getx(p) = i32.load(p)` reads linear memory. The by-body modeler
+        // must encode that load against the caller's shared memory Array, so:
+        //   (a) inlining `i32.load(p)` (offset 0) MUST verify (Ok(true)); and
+        //   (b) inlining a DIFFERENT load `i32.load(p) offset=4` (reads another
+        //       address) MUST be rejected (Ok(false)).
+        // (a) failing would mean memory-reading inlines can't be proven (the
+        // pre-#155 no-op); (b) passing would mean the modeler ignores the load
+        // address — unsound. Both are locked here.
+        use crate::verify::{
+            VerificationSignatureContext, verify_function_equivalence_with_context,
+        };
+        let wat = r#"(module
+            (memory 1)
+            (func $getx (param i32) (result i32)
+                local.get 0
+                i32.load)
+            (func $caller (param i32) (result i32)
+                local.get 0
+                call 0)
+        )"#;
+        let module = parse::parse_wat(wat).expect("parse");
+        let ctx = VerificationSignatureContext::from_module(&module);
+        // Original: `local.get 0; call $getx` (getx reads memory at p).
+        let orig = module.functions[1].clone();
+
+        // (a) Correct inline: load at the same address — must be PROVEN.
+        let mut correct = orig.clone();
+        correct.instructions = vec![
+            Instruction::LocalGet(0),
+            Instruction::I32Load {
+                offset: 0,
+                align: 2,
+                mem: 0,
+            },
+        ];
+        assert!(
+            verify_function_equivalence_with_context(&orig, &correct, "test", &ctx)
+                .expect("verify ok"),
+            "correct memory-load inline (i32.load p) must be proven equivalent to call getx",
+        );
+
+        // (b) WRONG inline: load 4 bytes higher — must be REJECTED.
+        let mut wrong = orig.clone();
+        wrong.instructions = vec![
+            Instruction::LocalGet(0),
+            Instruction::I32Load {
+                offset: 4,
+                align: 2,
+                mem: 0,
+            },
+        ];
+        assert!(
+            !verify_function_equivalence_with_context(&orig, &wrong, "test", &ctx)
+                .expect("verify ok"),
+            "SOUNDNESS: wrong memory-load inline (offset=4) must NOT verify against call getx",
         );
     }
 

--- a/loom-core/src/verify.rs
+++ b/loom-core/src/verify.rs
@@ -204,20 +204,31 @@ fn callee_inlinable_by_body(func: &Function) -> bool {
     if func.signature.results.len() != 1 {
         return false;
     }
-    func.instructions.iter().all(is_pure_total_statefree_instr)
+    func.instructions.iter().all(is_inline_modelable_instr)
 }
 
-/// loom#151: whitelist of straight-line instructions that are pure, total
-/// (never trap), and reference no state beyond locals/stack. Anything not
-/// listed (control flow, calls, memory, globals, div/rem, floats, …)
-/// disqualifies the callee from by-body modeling.
+/// loom#151/#155: whitelist of instructions the by-body inline modeler can
+/// encode faithfully and **identically to the main encoder**. The callee must
+/// be straight-line (no Block/Loop/If), leaf (no calls), single-result, and
+/// use only: constants, locals (no globals), stack shuffles, total integer
+/// arithmetic/bitwise/compare/convert (no div/rem, no floats), and — added in
+/// loom#155 — **full-width i32/i64 loads** (no stores, no partial-width).
+///
+/// SOUNDNESS of allowing loads: a load is neither "total" (it can trap OOB)
+/// nor state-free, but it is still sound for the *inline-equivalence* check.
+/// Both the original's modeled `call F` and the optimized's inlined body run
+/// the SAME load at the SAME address against the SAME shared memory `Array`
+/// via the SAME helper (`encode_i32_load_from`/`encode_i64_load_from`), so
+/// they produce bit-identical expressions — and any real OOB trap occurs
+/// identically on both sides, so the transformation preserves trap behavior
+/// regardless of loom's (non-trapping) Array model. Stores/globals/partial-
+/// width loads stay OUT (writes would need memory write-back; partial-width
+/// loads aren't full-width-modeled) → such callees fall back conservatively.
 #[cfg(feature = "verification")]
-fn is_pure_total_statefree_instr(instr: &Instruction) -> bool {
-    // IMPORTANT: this set must stay a SUBSET of what `encode_simple_instruction`
-    // models faithfully (correct value AND width). An op outside that set
-    // would be encoded as a wrong-width / opaque value, which the width
-    // guard in `encode_inlinable_callee_result` rejects (→ conservative
-    // fallback), but keeping the two in lock-step is the clearer invariant.
+fn is_inline_modelable_instr(instr: &Instruction) -> bool {
+    // Non-load ops here must stay a SUBSET of what `encode_simple_instruction`
+    // models faithfully; the full-width loads are intercepted directly in
+    // `encode_inlinable_callee_result` (shared helper), not delegated.
     use Instruction::*;
     matches!(
         instr,
@@ -227,6 +238,8 @@ fn is_pure_total_statefree_instr(instr: &Instruction) -> bool {
         | LocalGet(_) | LocalSet(_) | LocalTee(_)
         // stack shuffles
         | Drop | Select
+        // full-width loads (loom#155) — read-only, shared-Array encoding
+        | I32Load { .. } | I64Load { .. }
         // i32 arithmetic / bitwise (total: no div/rem)
         | I32Add | I32Sub | I32Mul | I32And | I32Or | I32Xor
         | I32Shl | I32ShrS | I32ShrU
@@ -252,7 +265,7 @@ fn is_pure_total_statefree_instr(instr: &Instruction) -> bool {
 /// selected, so the body is straight-line and state-free; `globals` is
 /// unused and `encode_block_body` never touches memory here.
 #[cfg(feature = "verification")]
-fn encode_inlinable_callee_result(func: &Function, args: &[BV]) -> Option<BV> {
+fn encode_inlinable_callee_result(func: &Function, args: &[BV], memory: &Array) -> Option<BV> {
     // Build the callee's local environment: params bound to the actual
     // arg BVs, then declared locals zero-initialized at their width.
     let mut locals: Vec<BV> = args.to_vec();
@@ -264,7 +277,29 @@ fn encode_inlinable_callee_result(func: &Function, args: &[BV]) -> Option<BV> {
     }
     let mut stack: Vec<BV> = Vec::new();
     let mut globals: Vec<BV> = Vec::new();
-    encode_block_body(&func.instructions, &mut stack, &mut locals, &mut globals).ok()?;
+    // Pre: `callee_inlinable_by_body(func)` held when this was selected, so the
+    // body is straight-line (no Block/Loop/If), leaf (no calls), and uses only
+    // whitelisted ops + full-width loads — no stores/globals. We can therefore
+    // execute it as a flat sequence. loom#155: full-width loads are encoded
+    // against the CALLER's shared memory `Array` via the SAME helpers the main
+    // encoder uses, so the original's modeled `call F` and the optimized's
+    // inlined body produce bit-identical expressions (aliasing/read-sees-write
+    // is sound by construction in the single-Array model).
+    for instr in &func.instructions {
+        match instr {
+            Instruction::I32Load { offset, .. } => {
+                let addr = stack.pop()?;
+                stack.push(encode_i32_load_from(memory, &addr, *offset).ok()?);
+            }
+            Instruction::I64Load { offset, .. } => {
+                let addr = stack.pop()?;
+                stack.push(encode_i64_load_from(memory, &addr, *offset).ok()?);
+            }
+            other => {
+                encode_simple_instruction(other, &mut stack, &mut locals, &mut globals).ok()?;
+            }
+        }
+    }
     let result = stack.last().cloned()?;
     let expected = bv_width_for_value_type(func.signature.results[0]);
     if result.get_size() == expected {
@@ -1021,6 +1056,45 @@ fn bv_width_for_value_type(t: crate::ValueType) -> u32 {
         crate::ValueType::I32 | crate::ValueType::F32 => 32,
         crate::ValueType::I64 | crate::ValueType::F64 => 64,
     }
+}
+
+/// loom#155: shared little-endian full-width load encoders.
+///
+/// SOUNDNESS: the main encoder (`encode_function_to_smt_impl_inner`) and the
+/// by-body inline modeler (`encode_inlinable_callee_result`) MUST encode the
+/// same load to the *same* Z3 expression — otherwise a memory-reading inline
+/// could be falsely accepted (if they coincidentally agree wrong) or, more
+/// usually, spuriously reverted. Factoring the byte-combine here and calling
+/// it from both sites guarantees bit-identical encoding against the shared
+/// memory `Array` (`Array[BitVec32 → BitVec8]`, little-endian).
+#[cfg(feature = "verification")]
+fn encode_i32_load_from(memory: &Array, addr: &BV, offset: u32) -> Result<BV> {
+    let effective_addr = addr.bvadd(BV::from_i64(offset as i64, 32));
+    let mut combined = BV::from_i64(0, 32);
+    for i in 0..4i64 {
+        let byte_addr = effective_addr.bvadd(BV::from_i64(i, 32));
+        let byte_val: BV = memory
+            .select(&byte_addr)
+            .as_bv()
+            .ok_or_else(|| anyhow!("Z3 memory select did not return BV in i32 load byte {}", i))?;
+        combined = combined.bvor(byte_val.zero_ext(24).bvshl(BV::from_i64(i * 8, 32)));
+    }
+    Ok(combined)
+}
+
+#[cfg(feature = "verification")]
+fn encode_i64_load_from(memory: &Array, addr: &BV, offset: u32) -> Result<BV> {
+    let effective_addr = addr.bvadd(BV::from_i64(offset as i64, 32));
+    let mut combined = BV::from_i64(0, 64);
+    for i in 0..8i64 {
+        let byte_addr = effective_addr.bvadd(BV::from_i64(i, 32));
+        let byte_val: BV = memory
+            .select(&byte_addr)
+            .as_bv()
+            .ok_or_else(|| anyhow!("Z3 memory select did not return BV in i64 load byte {}", i))?;
+        combined = combined.bvor(byte_val.zero_ext(56).bvshl(BV::from_i64(i * 8, 64)));
+    }
+    Ok(combined)
 }
 
 /// Resolve the wasm-declared `ValueType` of local index `idx` in `func`.
@@ -3082,6 +3156,17 @@ fn encode_function_to_smt_impl_inner(
     // use the same symbolic names for corresponding operations
     let mut memory_grow_count: u64 = 0;
 
+    // loom#155: per-encode counter for impure-call havoc names. MUST be local
+    // (not a global static): the original and optimized functions are encoded
+    // by separate calls into the SAME Z3 context, so a local counter that
+    // resets to 0 each encode gives the Nth impure call the SAME havoc'd
+    // global/memory name in both encodings — which makes those havoc'd arrays
+    // UNIFY in Z3. Without this, a result that depends on post-impure-call
+    // memory/globals (e.g. inlining a callee that reads what a preceding
+    // havoc'd call left behind) would compare two differently-named arrays and
+    // revert spuriously. A global counter never unified them.
+    let mut havoc_counter: u64 = 0;
+
     if let Some(shared) = shared_inputs {
         // Use shared inputs - CRITICAL for correct verification
         locals = shared.initial_locals.clone();
@@ -3897,45 +3982,8 @@ fn encode_function_to_smt_impl_inner(
                 }
                 // SAFETY: guarded by is_empty check above
                 let addr = stack.pop().unwrap();
-                let effective_addr = addr.bvadd(BV::from_i64(*offset as i64, 32));
-
-                // Read 4 bytes in little-endian order and combine into 32-bit
-                // memory.select returns Dynamic, cast to BV via as_bv()
-                let byte0: BV = memory.select(&effective_addr).as_bv().ok_or_else(|| {
-                    anyhow!("Z3 memory select did not return BV in I32Load byte 0")
-                })?;
-                let byte1: BV = memory
-                    .select(&effective_addr.bvadd(BV::from_i64(1, 32)))
-                    .as_bv()
-                    .ok_or_else(|| {
-                        anyhow!("Z3 memory select did not return BV in I32Load byte 1")
-                    })?;
-                let byte2: BV = memory
-                    .select(&effective_addr.bvadd(BV::from_i64(2, 32)))
-                    .as_bv()
-                    .ok_or_else(|| {
-                        anyhow!("Z3 memory select did not return BV in I32Load byte 2")
-                    })?;
-                let byte3: BV = memory
-                    .select(&effective_addr.bvadd(BV::from_i64(3, 32)))
-                    .as_bv()
-                    .ok_or_else(|| {
-                        anyhow!("Z3 memory select did not return BV in I32Load byte 3")
-                    })?;
-
-                // Zero-extend each byte to 32 bits
-                let b0 = byte0.zero_ext(24);
-                let b1 = byte1.zero_ext(24);
-                let b2 = byte2.zero_ext(24);
-                let b3 = byte3.zero_ext(24);
-
-                // Combine: result = b3 << 24 | b2 << 16 | b1 << 8 | b0
-                let result = b0
-                    .bvor(b1.bvshl(BV::from_i64(8, 32)))
-                    .bvor(b2.bvshl(BV::from_i64(16, 32)))
-                    .bvor(b3.bvshl(BV::from_i64(24, 32)));
-
-                stack.push(result);
+                // loom#155: shared encoder (also used by by-body inline modeling).
+                stack.push(encode_i32_load_from(&memory, &addr, *offset)?);
             }
             Instruction::I32Store { offset, .. } => {
                 if stack.len() < 2 {
@@ -3964,19 +4012,8 @@ fn encode_function_to_smt_impl_inner(
                 }
                 // SAFETY: guarded by is_empty check above
                 let addr = stack.pop().unwrap();
-                let effective_addr = addr.bvadd(BV::from_i64(*offset as i64, 32));
-
-                // Read 8 bytes in little-endian order
-                let mut result = BV::from_i64(0, 64);
-                for i in 0..8i64 {
-                    let byte_addr = effective_addr.bvadd(BV::from_i64(i, 32));
-                    let byte_val: BV = memory.select(&byte_addr).as_bv().ok_or_else(|| {
-                        anyhow!("Z3 memory select did not return BV in I64Load byte {}", i)
-                    })?;
-                    let extended = byte_val.zero_ext(56);
-                    result = result.bvor(extended.bvshl(BV::from_i64(i * 8, 64)));
-                }
-                stack.push(result);
+                // loom#155: shared encoder (also used by by-body inline modeling).
+                stack.push(encode_i64_load_from(&memory, &addr, *offset)?);
             }
             Instruction::I64Store { offset, .. } => {
                 if stack.len() < 2 {
@@ -4495,11 +4532,14 @@ fn encode_function_to_smt_impl_inner(
                         // conservative encoding (at worst a spurious
                         // revert, never an unsound accept).
                         if let Some(callee) = ctx_ref.inlinable_callee_body(*func_idx) {
-                            if let Some(result_bv) = encode_inlinable_callee_result(&callee, &args)
+                            if let Some(result_bv) =
+                                encode_inlinable_callee_result(&callee, &args, &memory)
                             {
                                 stack.push(result_bv);
-                                // Pure + no-trap + state-free: no
-                                // global/memory havoc required.
+                                // loom#155: the callee may READ memory; its
+                                // loads were encoded against the current shared
+                                // `memory` Array. It performs no stores/globals
+                                // (whitelist), so no havoc is required.
                                 continue;
                             }
                         }
@@ -4579,10 +4619,11 @@ fn encode_function_to_smt_impl_inner(
                             // Havoc all globals that this function might modify.
                             // Conservative but sound - we assume the call could
                             // modify any global it has write access to.
-                            static CALL_COUNTER: std::sync::atomic::AtomicU64 =
-                                std::sync::atomic::AtomicU64::new(0);
-                            let call_id =
-                                CALL_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            // loom#155: deterministic per-encode id (see
+                            // `havoc_counter` decl) so corresponding calls in
+                            // the original/optimized encodings unify in Z3.
+                            let call_id = havoc_counter;
+                            havoc_counter += 1;
                             for (idx, global) in globals.iter_mut().enumerate() {
                                 *global = BV::new_const(
                                     format!("global_{}_after_call_{}_{}", idx, func_idx, call_id),
@@ -4671,7 +4712,7 @@ fn encode_function_to_smt_impl_inner(
                             // break.
                             if let Some(callee) = ctx_ref.inlinable_callee_body(func_idx) {
                                 if let Some(result_bv) =
-                                    encode_inlinable_callee_result(&callee, &args)
+                                    encode_inlinable_callee_result(&callee, &args, &memory)
                                 {
                                     stack.push(result_bv);
                                     continue;


### PR DESCRIPTION
## gale #155 — verified inlining of memory-reading callees

Delivers the gale `flight_control` seam: inlining `controller_step` (reads the `flight_state` a preceding `filter_step` call wrote) into its caller, **proven** by the Z3 translation validator. General, not gale-specific.

### How
- **Memory-through verification:** by-body inline modeling threads the caller's shared memory `Array` and encodes full-width `i32`/`i64` loads via helpers **shared with the main encoder** → original modeled-`call F` and optimized inlined-body are bit-identical. Aliasing/read-sees-write sound by construction (single-Array model).
- **Deterministic havoc:** per-encode counter (was global) so corresponding impure calls unify across the two encodings — required for a reader inlined after an opaque (havoc'd) writer.
- **Writers not inlined:** a memory/global-writing callee stays an opaque call (the validator havocs a *remaining* call; an *inlined* writer's concrete stores would diverge once observed → false counterexample). Exactly gale's ask: `filter_step` stays a call, `controller_step` inlines.
- **Single-call-site inline budget** raised (200), staying under the Z3 verify cap so inlines remain proven.

### Validation
- Soundness guards: `test_inline_verifier_proves_and_rejects_memory_load_inline` (proves correct load inline, rejects wrong offset) + `test_inline_memory_seam_reader_inlined_writer_kept`. **389 lib tests pass.**
- gale `min_seam` oracle matches native **bit-for-bit** (`clamp(v + v>>1, -127,127)`); drive-free `flight_seam` inlines `controller_step` (142→228) proven, valid.
- Integration: only the 7 pre-existing #150 LICM/DCE failures (unchanged).

### Known-red gates (pre-existing)
- **Rocq Formal Proofs** — upstream toolchain.
- **Test matrix / Coverage** — the 7 #150 failures (fail identically on v1.1.1; untouched here).

Closes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)