### PR TITLE
feat(verify): inline memory-writing callees via by-body store modeling (closes #157, v1.1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to LOOM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.7] - 2026-06-02
+
+**Optimization release: verified inlining of memory-*writing* callees (#157).**
+The writer half of the #155 seam — full-width stores are now modeled by-body,
+so a memory-writing callee inlines+verifies (no longer forced to stay opaque).
+On the gale `min_seam` repro the seam now **fully dissolves** (both writer and
+reader inlined, 0 calls) and reproduces the native oracle bit-for-bit.
+
+### Added / Changed
+
+- **By-body store modeling.** `encode_inlinable_callee_result` applies a
+  callee's full-width `i32`/`i64` **stores** to the shared memory `Array` (via
+  new `encode_i32_store_into` / `encode_i64_store_into` helpers **shared with
+  the main encoder**) and **threads the updated Array back** to the caller. So
+  the original's modeled `call F` and the optimized's inlined body produce
+  bit-identical loads *and* memory updates — the writer's call is modeled
+  concretely on both sides, removing the havoc-vs-concrete divergence that
+  previously forced writers to stay opaque (#155).
+- **Void callees inline.** A zero-result callee (a pure writer `void wr(*s,v)`)
+  now inlines: no value, but a possibly-updated memory Array.
+- The by-body whitelist gains full-width `i32.store` / `i64.store`. **Unmodeled
+  writes stay opaque:** partial-width stores, float stores, `global.set`, and
+  `memory.*` bulk ops still disqualify a callee (conservative — they'd diverge
+  from the original's havoc). Partial-width load/store modeling is future work.
+
+### Validation
+
+- New soundness guard `test_inline_verifier_proves_and_rejects_memory_store_inline`
+  (proves a correct `*s=v; read *s` inline, rejects a wrong `*(s+4)=v` one) and
+  `test_inline_memory_seam_fully_dissolves`. 389 lib tests pass.
+- gale's `min_seam` inlines **both** `wr` and `rd` (0 calls), wasmtime oracle
+  matches native bit-for-bit (`clamp(v + (v>>1), -127, 127)`).
+- Integration suite unchanged: only the 7 pre-existing #150 failures.
+
 ## [1.1.6] - 2026-06-02
 
 **Optimization release: verified inlining of memory-reading callees (#155).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.6"
+version = "1.1.7"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -13285,22 +13285,19 @@ pub mod optimize {
                 }
                 // loom#155: do NOT inline a callee that WRITES memory/globals.
                 // The translation validator models a *remaining* call's effects
-                // as a havoc (fresh symbolic state), but an *inlined* writer
-                // performs concrete stores — so if any later code (e.g. an
-                // inlined reader, the gale filter_step→controller_step seam)
-                // observes that state, the original (havoc) and optimized
-                // (concrete) encodings diverge and the verifier reverts with a
-                // FALSE counterexample. By-body inline modeling is read-only
-                // (loom#155), so writers can't be proven yet: keep them as
-                // opaque calls (the deterministic havoc makes a following
-                // reader's inline provable against the SAME havoc'd state).
-                // This is exactly the gale ask: "filter_step can stay an opaque
-                // call; I only need controller_step inlined."
+                // as a havoc, but an *inlined* writer performs concrete stores
+                // — so if later code observes that state, the original (havoc)
+                // and optimized (concrete) encodings diverge → false revert.
+                // loom#157: full-width i32/i64 stores are now by-body modeled
+                // (concrete on BOTH sides → no divergence), so a full-width
+                // writer like `wr` CAN inline+verify. Only callees with
+                // UNMODELED writes (partial-width/float stores, globals,
+                // memory.* bulk ops) must still stay opaque calls.
                 if let Some(callee) = module
                     .functions
                     .get((*func_idx - num_imported_funcs) as usize)
                 {
-                    if function_writes_state(callee) {
+                    if function_has_unmodelable_writes(callee) {
                         continue;
                     }
                 }
@@ -13409,12 +13406,16 @@ pub mod optimize {
     /// translation validator models a remaining call's effects as a havoc,
     /// which an inlined writer's concrete stores would not match once observed
     /// (see the candidate-loop comment). Recurses into control flow.
-    fn function_writes_state(func: &super::Function) -> bool {
+    fn function_has_unmodelable_writes(func: &super::Function) -> bool {
         fn body_writes(instrs: &[Instruction]) -> bool {
             instrs.iter().any(|i| match i {
-                Instruction::I32Store { .. }
-                | Instruction::I64Store { .. }
-                | Instruction::F32Store { .. }
+                // loom#157: full-width i32/i64 stores ARE now by-body modeled
+                // (the verifier applies them to the shared memory Array and
+                // threads it back), so they no longer disqualify a callee. The
+                // remaining writes below are NOT modeled, so such a callee must
+                // stay an opaque (havoc) call — inlining it would diverge from
+                // the original's havoc once the writes are observed downstream:
+                Instruction::F32Store { .. }
                 | Instruction::F64Store { .. }
                 | Instruction::I32Store8 { .. }
                 | Instruction::I32Store16 { .. }
@@ -18544,8 +18545,85 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "verification")]
     #[test]
-    fn test_inline_memory_seam_reader_inlined_writer_kept() {
+    fn test_inline_verifier_proves_and_rejects_memory_store_inline() {
+        // loom#157 SOUNDNESS GUARD for by-body STORE modeling. `wr(s,v){ *s=v }`
+        // writes memory; `caller(s,v){ wr(s,v); return *s }` calls it then reads
+        // back. The by-body modeler must apply wr's store to the shared Array so
+        // the readback observes it. Then:
+        //   (a) inlining the correct store (`*s=v`) MUST verify (Ok(true)); and
+        //   (b) inlining a WRONG store (`*(s+4)=v`, leaving *s unwritten) MUST be
+        //       rejected (Ok(false)) — the readback would differ.
+        use crate::verify::{
+            VerificationSignatureContext, verify_function_equivalence_with_context,
+        };
+        let wat = r#"(module
+            (memory 1)
+            (func $wr (param i32 i32)
+                local.get 0
+                local.get 1
+                i32.store)
+            (func $caller (param i32 i32) (result i32)
+                local.get 0
+                local.get 1
+                call 0
+                local.get 0
+                i32.load)
+        )"#;
+        let module = parse::parse_wat(wat).expect("parse");
+        let ctx = VerificationSignatureContext::from_module(&module);
+        let orig = module.functions[1].clone(); // wr(s,v); return *s
+
+        // (a) correct store inline: store v at *s, then read *s back → v.
+        let mut correct = orig.clone();
+        correct.instructions = vec![
+            Instruction::LocalGet(0),
+            Instruction::LocalGet(1),
+            Instruction::I32Store {
+                offset: 0,
+                align: 2,
+                mem: 0,
+            },
+            Instruction::LocalGet(0),
+            Instruction::I32Load {
+                offset: 0,
+                align: 2,
+                mem: 0,
+            },
+        ];
+        assert!(
+            verify_function_equivalence_with_context(&orig, &correct, "test", &ctx)
+                .expect("verify ok"),
+            "correct store inline (*s=v; read *s) must be proven equivalent to call wr",
+        );
+
+        // (b) WRONG store inline: store at *(s+4); *s stays unwritten → readback differs.
+        let mut wrong = orig.clone();
+        wrong.instructions = vec![
+            Instruction::LocalGet(0),
+            Instruction::LocalGet(1),
+            Instruction::I32Store {
+                offset: 4,
+                align: 2,
+                mem: 0,
+            },
+            Instruction::LocalGet(0),
+            Instruction::I32Load {
+                offset: 0,
+                align: 2,
+                mem: 0,
+            },
+        ];
+        assert!(
+            !verify_function_equivalence_with_context(&orig, &wrong, "test", &ctx)
+                .expect("verify ok"),
+            "SOUNDNESS: wrong store inline (offset=4) must NOT verify against call wr",
+        );
+    }
+
+    #[test]
+    fn test_inline_memory_seam_fully_dissolves() {
         // loom#155: the gale flight_control seam — `seam(s,v){ wr(s,v); return
         // rd(s); }` where `wr` WRITES *s and `rd` READS it. loom must inline
         // the reader `rd` (proven against the havoc'd memory left by the
@@ -18607,11 +18685,14 @@ mod tests {
             .count();
         assert_eq!(
             rd_after, 0,
-            "memory-reading callee rd must be inlined (proven via memory-through modeling)"
+            "memory-reading callee rd must be inlined (proven via memory-through modeling, #155)"
         );
+        // loom#157: the full-width-store writer `wr` is now ALSO inlined+proven
+        // (its stores are modeled against the shared memory Array on both
+        // sides), so the seam fully dissolves — 0 calls remain.
         assert_eq!(
-            wr_after, 1,
-            "memory-writing callee wr must NOT be inlined (kept as opaque havoc call)"
+            wr_after, 0,
+            "memory-writing callee wr must now be inlined too (by-body store modeling, #157)"
         );
         let wasm_bytes = encode::encode_wasm(&module).expect("encode");
         wasmparser::validate(&wasm_bytes).expect("output validates");

--- a/loom-core/src/verify.rs
+++ b/loom-core/src/verify.rs
@@ -199,9 +199,11 @@ impl VerificationSignatureContext {
 /// addition gated by its own soundness argument.
 #[cfg(feature = "verification")]
 fn callee_inlinable_by_body(func: &Function) -> bool {
-    // Single result only — multi-value needs tuple plumbing the encoder
-    // does not have, and zero-result calls are never inlined for value.
-    if func.signature.results.len() != 1 {
+    // At most one result: multi-value needs tuple plumbing the encoder does
+    // not have. loom#157: zero-result (void) callees ARE allowed now — a pure
+    // writer (`void wr(*s, v)`) returns no value but updates memory, which the
+    // by-body modeler threads back to the caller.
+    if func.signature.results.len() > 1 {
         return false;
     }
     func.instructions.iter().all(is_inline_modelable_instr)
@@ -238,8 +240,10 @@ fn is_inline_modelable_instr(instr: &Instruction) -> bool {
         | LocalGet(_) | LocalSet(_) | LocalTee(_)
         // stack shuffles
         | Drop | Select
-        // full-width loads (loom#155) — read-only, shared-Array encoding
+        // full-width loads (loom#155) + stores (loom#157) — shared-Array
+        // encoding; stores thread the updated memory back to the caller
         | I32Load { .. } | I64Load { .. }
+        | I32Store { .. } | I64Store { .. }
         // i32 arithmetic / bitwise (total: no div/rem)
         | I32Add | I32Sub | I32Mul | I32And | I32Or | I32Xor
         | I32Shl | I32ShrS | I32ShrU
@@ -265,7 +269,11 @@ fn is_inline_modelable_instr(instr: &Instruction) -> bool {
 /// selected, so the body is straight-line and state-free; `globals` is
 /// unused and `encode_block_body` never touches memory here.
 #[cfg(feature = "verification")]
-fn encode_inlinable_callee_result(func: &Function, args: &[BV], memory: &Array) -> Option<BV> {
+fn encode_inlinable_callee_result(
+    func: &Function,
+    args: &[BV],
+    memory: &Array,
+) -> Option<(Option<BV>, Array)> {
     // Build the callee's local environment: params bound to the actual
     // arg BVs, then declared locals zero-initialized at their width.
     let mut locals: Vec<BV> = args.to_vec();
@@ -278,32 +286,52 @@ fn encode_inlinable_callee_result(func: &Function, args: &[BV], memory: &Array) 
     let mut stack: Vec<BV> = Vec::new();
     let mut globals: Vec<BV> = Vec::new();
     // Pre: `callee_inlinable_by_body(func)` held when this was selected, so the
-    // body is straight-line (no Block/Loop/If), leaf (no calls), and uses only
-    // whitelisted ops + full-width loads — no stores/globals. We can therefore
-    // execute it as a flat sequence. loom#155: full-width loads are encoded
-    // against the CALLER's shared memory `Array` via the SAME helpers the main
-    // encoder uses, so the original's modeled `call F` and the optimized's
-    // inlined body produce bit-identical expressions (aliasing/read-sees-write
-    // is sound by construction in the single-Array model).
+    // body is straight-line (no Block/Loop/If), leaf (no calls), single-or-zero
+    // result, and uses only whitelisted ops + full-width loads/stores — no
+    // globals/partial-width. We execute it as a flat sequence.
+    //   loom#155: full-width LOADS are encoded against the CALLER's shared
+    //   memory `Array` via the SAME helpers the main encoder uses.
+    //   loom#157: full-width STORES are applied to that Array and the updated
+    //   Array is RETURNED to the caller — so the original's modeled `call F`
+    //   and the optimized's inlined body produce bit-identical loads AND
+    //   memory updates. Modeling the writer's call by-body (concrete stores)
+    //   is what removes the old havoc-vs-concrete divergence: both sides now
+    //   carry the same stores, so a following read matches → provable.
+    let mut mem = memory.clone();
     for instr in &func.instructions {
         match instr {
             Instruction::I32Load { offset, .. } => {
                 let addr = stack.pop()?;
-                stack.push(encode_i32_load_from(memory, &addr, *offset).ok()?);
+                stack.push(encode_i32_load_from(&mem, &addr, *offset).ok()?);
             }
             Instruction::I64Load { offset, .. } => {
                 let addr = stack.pop()?;
-                stack.push(encode_i64_load_from(memory, &addr, *offset).ok()?);
+                stack.push(encode_i64_load_from(&mem, &addr, *offset).ok()?);
+            }
+            Instruction::I32Store { offset, .. } => {
+                let value = stack.pop()?;
+                let addr = stack.pop()?;
+                mem = encode_i32_store_into(&mem, &addr, &value, *offset);
+            }
+            Instruction::I64Store { offset, .. } => {
+                let value = stack.pop()?;
+                let addr = stack.pop()?;
+                mem = encode_i64_store_into(&mem, &addr, &value, *offset);
             }
             other => {
                 encode_simple_instruction(other, &mut stack, &mut locals, &mut globals).ok()?;
             }
         }
     }
+    // Zero-result (void) callees — e.g. a pure writer — return no value but a
+    // possibly-updated memory. Single-result callees width-check the result.
+    if func.signature.results.is_empty() {
+        return Some((None, mem));
+    }
     let result = stack.last().cloned()?;
     let expected = bv_width_for_value_type(func.signature.results[0]);
     if result.get_size() == expected {
-        Some(result)
+        Some((Some(result), mem))
     } else {
         None
     }
@@ -1095,6 +1123,33 @@ fn encode_i64_load_from(memory: &Array, addr: &BV, offset: u32) -> Result<BV> {
         combined = combined.bvor(byte_val.zero_ext(56).bvshl(BV::from_i64(i * 8, 64)));
     }
     Ok(combined)
+}
+
+/// loom#157: shared little-endian full-width store encoders — the write
+/// counterparts of the load helpers, reused by the main encoder and the
+/// by-body inline modeler so an inlined writer's stores and the original
+/// modeled-`call F`'s stores produce bit-identical memory `Array` updates.
+/// Returns the new memory Array (Z3 arrays are functional/immutable).
+#[cfg(feature = "verification")]
+fn encode_i32_store_into(memory: &Array, addr: &BV, value: &BV, offset: u32) -> Array {
+    let effective_addr = addr.bvadd(BV::from_i64(offset as i64, 32));
+    let mut m = memory.clone();
+    for i in 0..4i64 {
+        let byte = value.extract((i * 8 + 7) as u32, (i * 8) as u32);
+        m = m.store(&effective_addr.bvadd(BV::from_i64(i, 32)), &byte);
+    }
+    m
+}
+
+#[cfg(feature = "verification")]
+fn encode_i64_store_into(memory: &Array, addr: &BV, value: &BV, offset: u32) -> Array {
+    let effective_addr = addr.bvadd(BV::from_i64(offset as i64, 32));
+    let mut m = memory.clone();
+    for i in 0..8i64 {
+        let byte = value.extract((i * 8 + 7) as u32, (i * 8) as u32);
+        m = m.store(&effective_addr.bvadd(BV::from_i64(i, 32)), &byte);
+    }
+    m
 }
 
 /// Resolve the wasm-declared `ValueType` of local index `idx` in `func`.
@@ -3992,19 +4047,8 @@ fn encode_function_to_smt_impl_inner(
                 // SAFETY: guarded by len check above
                 let value = stack.pop().unwrap();
                 let addr = stack.pop().unwrap();
-                let effective_addr = addr.bvadd(BV::from_i64(*offset as i64, 32));
-
-                // Extract 4 bytes from 32-bit value (little-endian)
-                let byte0 = value.extract(7, 0);
-                let byte1 = value.extract(15, 8);
-                let byte2 = value.extract(23, 16);
-                let byte3 = value.extract(31, 24);
-
-                // Store each byte
-                memory = memory.store(&effective_addr, &byte0);
-                memory = memory.store(&effective_addr.bvadd(BV::from_i64(1, 32)), &byte1);
-                memory = memory.store(&effective_addr.bvadd(BV::from_i64(2, 32)), &byte2);
-                memory = memory.store(&effective_addr.bvadd(BV::from_i64(3, 32)), &byte3);
+                // loom#157: shared encoder (also used by by-body inline modeling).
+                memory = encode_i32_store_into(&memory, &addr, &value, *offset);
             }
             Instruction::I64Load { offset, .. } => {
                 if stack.is_empty() {
@@ -4022,14 +4066,8 @@ fn encode_function_to_smt_impl_inner(
                 // SAFETY: guarded by len check above
                 let value = stack.pop().unwrap();
                 let addr = stack.pop().unwrap();
-                let effective_addr = addr.bvadd(BV::from_i64(*offset as i64, 32));
-
-                // Store 8 bytes (little-endian)
-                for i in 0..8i64 {
-                    let byte_val = value.extract((i * 8 + 7) as u32, (i * 8) as u32);
-                    let byte_addr = effective_addr.bvadd(BV::from_i64(i, 32));
-                    memory = memory.store(&byte_addr, &byte_val);
-                }
+                // loom#157: shared encoder (also used by by-body inline modeling).
+                memory = encode_i64_store_into(&memory, &addr, &value, *offset);
             }
 
             // Partial-width loads (8-bit and 16-bit with sign/zero extension)
@@ -4532,14 +4570,20 @@ fn encode_function_to_smt_impl_inner(
                         // conservative encoding (at worst a spurious
                         // revert, never an unsound accept).
                         if let Some(callee) = ctx_ref.inlinable_callee_body(*func_idx) {
-                            if let Some(result_bv) =
+                            if let Some((result_bv, new_mem)) =
                                 encode_inlinable_callee_result(&callee, &args, &memory)
                             {
-                                stack.push(result_bv);
-                                // loom#155: the callee may READ memory; its
-                                // loads were encoded against the current shared
-                                // `memory` Array. It performs no stores/globals
-                                // (whitelist), so no havoc is required.
+                                // loom#155/#157: the callee may READ and/or WRITE
+                                // memory; its loads/stores were encoded against
+                                // the current shared `memory` Array via the same
+                                // helpers the main encoder uses. Apply its memory
+                                // effects (no havoc — the writes are concrete and
+                                // modeled identically on both sides). Push the
+                                // result only for non-void callees.
+                                memory = new_mem;
+                                if let Some(bv) = result_bv {
+                                    stack.push(bv);
+                                }
                                 continue;
                             }
                         }
@@ -4711,10 +4755,13 @@ fn encode_function_to_smt_impl_inner(
                             // `call_indirect` ⇔ `call F` equivalence would
                             // break.
                             if let Some(callee) = ctx_ref.inlinable_callee_body(func_idx) {
-                                if let Some(result_bv) =
+                                if let Some((result_bv, new_mem)) =
                                     encode_inlinable_callee_result(&callee, &args, &memory)
                                 {
-                                    stack.push(result_bv);
+                                    memory = new_mem;
+                                    if let Some(bv) = result_bv {
+                                        stack.push(bv);
+                                    }
                                     continue;
                                 }
                             }


### PR DESCRIPTION
## gale #157 — writer side of the #155 seam

v1.1.6 inlined memory-**reading** callees; this lands the **writer** half. Full-width stores are now modeled by-body, so a memory-writing callee inlines+verifies — the gale `min_seam` fully dissolves (both `wr` and `rd` inlined, 0 calls).

### How
- **By-body store modeling:** `encode_inlinable_callee_result` applies the callee's full-width `i32`/`i64` stores to the shared memory `Array` via helpers **shared with the main encoder**, and **threads the updated Array back** to the caller → original modeled-`call F` and optimized inlined-body produce bit-identical loads *and* memory updates. Modeling the writer concretely on both sides removes the havoc-vs-concrete divergence that forced writers opaque in #155.
- **Void callees inline** (a pure writer returns no value, just updated memory).
- Whitelist += full-width stores; **unmodeled writes stay opaque** (partial-width/float stores, `global.set`, `memory.*` bulk ops) — conservative.

### Validation
- Soundness guards: `test_inline_verifier_proves_and_rejects_memory_store_inline` (proves correct `*s=v; read` inline, rejects wrong `*(s+4)=v`) + `test_inline_memory_seam_fully_dissolves`. **389 lib tests pass.**
- gale `min_seam`: both `wr`+`rd` inlined (0 calls), wasmtime oracle bit-for-bit vs native (`clamp(v + v>>1, -127,127)`).
- Integration: only the 7 pre-existing #150 failures.

### Known-red gates (pre-existing)
- **Rocq Formal Proofs** — upstream toolchain.
- **Test matrix / Coverage** — the 7 #150 failures (unchanged).

Closes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)