### PR TITLE
feat(verify): inline callees with partial-width loads/stores (closes #161, v1.1.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to LOOM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.9] - 2026-06-02
+
+**Optimization release: inline callees with partial-width loads/stores (#161).**
+By-body inline modeling now handles partial-width i32 memory access
+(`i32.load8_s/u`, `i32.load16_s/u`, `i32.store8/16` — `int8_t`/`int16_t`
+fields), so a callee reading/writing those fields inlines+verifies. gale's
+`seam16` (int16 seam) now fully dissolves and reproduces the native oracle
+bit-for-bit, including the int16-wrap vector.
+
+### Added
+
+- **Partial-width load/store modeling** in by-body inlining, via shared
+  helpers `encode_partial_load_from` (reads `bytes` LE then sign-/zero-extends
+  to the result width) and `encode_partial_store_into` (stores the low bytes).
+  They produce the same encoding the main encoder already used for these ops,
+  so an inlined partial-width access and the original modeled call are
+  bit-identical. The by-body whitelist (`is_inline_modelable_instr`) and the
+  inline candidate filter gain `i32.load8_s/u`, `i32.load16_s/u`,
+  `i32.store8/16`. (The skip gate already treated integer partial-width ops as
+  verifiable; only the inline whitelist needed them.)
+
+### Validation
+
+- New `test_inline_partial_width_seam_fully_dissolves` (int16 writer+reader
+  seam → 0 calls). The #159 guard now uses `i32.div_s` for its "un-modelable
+  writer" (partial-width is modelable as of this release). 391 lib tests pass.
+- gale's `seam16` fully dissolves (0 calls); wasmtime oracle matches native
+  bit-for-bit incl. **v=70000 → -127** (exercises int16 truncation/sign-ext —
+  a wrong width would diverge here). `flight_seam`'s `controller_step` still
+  inlines; `filter_step` stays opaque — now because of `i32.div_s` (integer
+  division, a separate limitation), not partial-width. Integration suite
+  unchanged (only the 7 #150 failures).
+
+### Note
+
+Full `flight_algo` dissolution additionally needs integer-division (`div_s`)
+modeling for `filter_step`; partial-width is no longer the blocker. (On-silicon
+payoff remains separately gated on synth#210.)
+
 ## [1.1.8] - 2026-06-02
 
 **Bug-fix release: restore the v1.1.6 reader-inline regressed by v1.1.7 (#159).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.8"
+version = "1.1.9"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -13433,6 +13433,12 @@ pub mod optimize {
                     | Instruction::I64Load { .. }
                     | Instruction::I32Store { .. }
                     | Instruction::I64Store { .. }
+                    | Instruction::I32Load8S { .. }
+                    | Instruction::I32Load8U { .. }
+                    | Instruction::I32Load16S { .. }
+                    | Instruction::I32Load16U { .. }
+                    | Instruction::I32Store8 { .. }
+                    | Instruction::I32Store16 { .. }
                     | Instruction::I32Add
                     | Instruction::I32Sub
                     | Instruction::I32Mul
@@ -18738,35 +18744,39 @@ mod tests {
     }
 
     #[test]
-    fn test_inline_reader_after_partial_width_writer() {
-        // loom#159 REGRESSION GUARD. A full-width READER (`rd`) following a
-        // PARTIAL-WIDTH WRITER (`pw`, `i32.store16` — not by-body-modelable,
-        // like the real `filter_step`'s `i32.load16_s`). The reader must still
-        // inline (proven against the writer's havoc'd memory) while the
-        // un-modelable writer stays an opaque call. v1.1.7 regressed this: `pw`
-        // became a candidate (its check looked only at writes), got inlined,
-        // diverged from the original's havoc → false revert that ALSO killed
-        // `rd`'s inline. The fix gates candidates on full inline-modelability.
+    fn test_inline_reader_after_unmodelable_writer() {
+        // loom#159 REGRESSION GUARD. A full-width READER (`rd`) following an
+        // UN-MODELABLE WRITER (`nm`, uses `i32.div_s` which the verifier can't
+        // model — div may trap). The reader must still inline (proven against
+        // the writer's havoc'd memory) while the un-modelable writer stays an
+        // opaque call. v1.1.7 regressed this: a non-modelable callee became a
+        // candidate (the filter looked only at writes), got inlined, diverged
+        // from the original's havoc → false revert that ALSO killed `rd`'s
+        // inline. The fix gates candidates on FULL inline-modelability.
+        // (NB: as of loom#161, partial-width `i32.store16` IS modelable and
+        // would inline — so this guard uses `i32.div_s` to stay un-modelable.)
         let wat = r#"(module
             (memory 1)
             (func $seam (export "seam") (param i32 i32) (result i32)
                 local.get 0
                 local.get 1
-                call $pw
+                call $nm
                 local.get 0
                 call $rd)
             (func $rd (param i32) (result i32)
                 local.get 0
                 i32.load)
-            (func $pw (param i32 i32)
+            (func $nm (param i32 i32)
                 local.get 0
                 local.get 1
-                i32.store16)
+                local.get 1
+                i32.div_s
+                i32.store)
         )"#;
         let mut module = parse::parse_wat(wat).expect("parse");
         optimize::inline_functions(&mut module).expect("must not panic");
         let seam = &module.functions[0];
-        // full idx: seam=0, rd=1, pw=2.
+        // full idx: seam=0, rd=1, nm=2.
         let rd_calls = seam
             .instructions
             .iter()
@@ -18779,11 +18789,54 @@ mod tests {
             .count();
         assert_eq!(
             rd_calls, 0,
-            "full-width reader must inline even after a partial-width writer (#159)"
+            "full-width reader must inline even after an un-modelable writer (#159)"
         );
         assert_eq!(
             pw_calls, 1,
-            "partial-width writer (i32.store16) must stay an opaque call (not modelable)"
+            "un-modelable writer (i32.div_s) must stay an opaque call"
+        );
+        let wasm_bytes = encode::encode_wasm(&module).expect("encode");
+        wasmparser::validate(&wasm_bytes).expect("output validates");
+    }
+
+    #[test]
+    fn test_inline_partial_width_seam_fully_dissolves() {
+        // loom#161: a seam over int16_t fields — writer `wr16` uses i32.store16,
+        // reader `rd16` uses i32.load16_s (sign-extended). Both are now by-body
+        // modelable (partial-width helpers), so the seam fully dissolves
+        // (0 calls), proven. Mirrors gale's seam16.
+        let wat = r#"(module
+            (memory 1)
+            (func $seam (export "seam") (param i32 i32) (result i32)
+                local.get 0
+                local.get 1
+                call $wr16
+                local.get 0
+                call $rd16)
+            (func $rd16 (param i32) (result i32)
+                local.get 0
+                i32.load16_s offset=2
+                local.get 0
+                i32.load16_s
+                i32.add)
+            (func $wr16 (param i32 i32)
+                local.get 0
+                local.get 1
+                i32.store16
+                local.get 0
+                local.get 1
+                i32.store16 offset=2)
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        optimize::inline_functions(&mut module).expect("must not panic");
+        let calls = module.functions[0]
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, Instruction::Call(_)))
+            .count();
+        assert_eq!(
+            calls, 0,
+            "partial-width seam must fully dissolve: both i32.store16 writer and i32.load16_s reader inline (#161)"
         );
         let wasm_bytes = encode::encode_wasm(&module).expect("encode");
         wasmparser::validate(&wasm_bytes).expect("output validates");

--- a/loom-core/src/verify.rs
+++ b/loom-core/src/verify.rs
@@ -244,6 +244,12 @@ fn is_inline_modelable_instr(instr: &Instruction) -> bool {
         // encoding; stores thread the updated memory back to the caller
         | I32Load { .. } | I64Load { .. }
         | I32Store { .. } | I64Store { .. }
+        // partial-width i32 loads/stores (loom#161) — int8_t/int16_t fields,
+        // e.g. filter_step's i32.load16_s. Encoded via the shared partial-width
+        // helpers (correct sign/zero-ext + masking).
+        | I32Load8S { .. } | I32Load8U { .. }
+        | I32Load16S { .. } | I32Load16U { .. }
+        | I32Store8 { .. } | I32Store16 { .. }
         // i32 arithmetic / bitwise (total: no div/rem)
         | I32Add | I32Sub | I32Mul | I32And | I32Or | I32Xor
         | I32Shl | I32ShrS | I32ShrU
@@ -317,6 +323,33 @@ fn encode_inlinable_callee_result(
                 let value = stack.pop()?;
                 let addr = stack.pop()?;
                 mem = encode_i64_store_into(&mem, &addr, &value, *offset);
+            }
+            // loom#161: partial-width i32 loads/stores (int8_t/int16_t fields).
+            Instruction::I32Load8S { offset, .. } => {
+                let addr = stack.pop()?;
+                stack.push(encode_partial_load_from(&mem, &addr, *offset, 1, true, 32).ok()?);
+            }
+            Instruction::I32Load8U { offset, .. } => {
+                let addr = stack.pop()?;
+                stack.push(encode_partial_load_from(&mem, &addr, *offset, 1, false, 32).ok()?);
+            }
+            Instruction::I32Load16S { offset, .. } => {
+                let addr = stack.pop()?;
+                stack.push(encode_partial_load_from(&mem, &addr, *offset, 2, true, 32).ok()?);
+            }
+            Instruction::I32Load16U { offset, .. } => {
+                let addr = stack.pop()?;
+                stack.push(encode_partial_load_from(&mem, &addr, *offset, 2, false, 32).ok()?);
+            }
+            Instruction::I32Store8 { offset, .. } => {
+                let value = stack.pop()?;
+                let addr = stack.pop()?;
+                mem = encode_partial_store_into(&mem, &addr, &value, *offset, 1);
+            }
+            Instruction::I32Store16 { offset, .. } => {
+                let value = stack.pop()?;
+                let addr = stack.pop()?;
+                mem = encode_partial_store_into(&mem, &addr, &value, *offset, 2);
             }
             other => {
                 encode_simple_instruction(other, &mut stack, &mut locals, &mut globals).ok()?;
@@ -1146,6 +1179,66 @@ fn encode_i64_store_into(memory: &Array, addr: &BV, value: &BV, offset: u32) -> 
     let effective_addr = addr.bvadd(BV::from_i64(offset as i64, 32));
     let mut m = memory.clone();
     for i in 0..8i64 {
+        let byte = value.extract((i * 8 + 7) as u32, (i * 8) as u32);
+        m = m.store(&effective_addr.bvadd(BV::from_i64(i, 32)), &byte);
+    }
+    m
+}
+
+/// loom#161: shared partial-width (8/16-bit) load encoder. Reads `bytes` bytes
+/// little-endian into a `bytes*8`-bit value, then sign- or zero-extends to
+/// `result_width` (32 or 64). Used by the main encoder AND the by-body inline
+/// modeler so a callee accessing `int8_t`/`int16_t` fields (e.g. filter_step's
+/// `i32.load16_s`) inlines with a bit-identical encoding. The v=70000 int16
+/// wrap vector in gale#161 validates the masked/sign-extended widths.
+#[cfg(feature = "verification")]
+fn encode_partial_load_from(
+    memory: &Array,
+    addr: &BV,
+    offset: u32,
+    bytes: u32,
+    signed: bool,
+    result_width: u32,
+) -> Result<BV> {
+    let effective_addr = addr.bvadd(BV::from_i64(offset as i64, 32));
+    let raw_width = bytes * 8;
+    let mut combined = BV::from_u64(0, raw_width);
+    for i in 0..bytes as i64 {
+        let byte: BV = memory
+            .select(&effective_addr.bvadd(BV::from_i64(i, 32)))
+            .as_bv()
+            .ok_or_else(|| anyhow!("Z3 memory select did not return BV in partial load"))?;
+        // byte is 8-bit; widen to raw_width and shift into place.
+        let widened = if raw_width > 8 {
+            byte.zero_ext(raw_width - 8)
+        } else {
+            byte
+        };
+        combined = combined.bvor(widened.bvshl(BV::from_u64((i * 8) as u64, raw_width)));
+    }
+    let ext = result_width - raw_width;
+    Ok(if ext == 0 {
+        combined
+    } else if signed {
+        combined.sign_ext(ext)
+    } else {
+        combined.zero_ext(ext)
+    })
+}
+
+/// loom#161: shared partial-width (8/16-bit) store encoder — stores the low
+/// `bytes` bytes of `value` little-endian. Counterpart of the partial load.
+#[cfg(feature = "verification")]
+fn encode_partial_store_into(
+    memory: &Array,
+    addr: &BV,
+    value: &BV,
+    offset: u32,
+    bytes: u32,
+) -> Array {
+    let effective_addr = addr.bvadd(BV::from_i64(offset as i64, 32));
+    let mut m = memory.clone();
+    for i in 0..bytes as i64 {
         let byte = value.extract((i * 8 + 7) as u32, (i * 8) as u32);
         m = m.store(&effective_addr.bvadd(BV::from_i64(i, 32)), &byte);
     }


### PR DESCRIPTION
## gale #161 — partial-width load/store inlining

By-body inline modeling now handles partial-width i32 memory access (`i32.load8_s/u`, `i32.load16_s/u`, `i32.store8/16` — `int8_t`/`int16_t` fields). gale's `seam16` fully dissolves, oracle bit-for-bit incl. the int16-wrap vector.

### How
- Shared `encode_partial_load_from` (read `bytes` LE, sign-/zero-extend to result width) + `encode_partial_store_into` — match the main encoder's existing partial-width encoding, so inlined access == original modeled call. Wired into `encode_inlinable_callee_result`; whitelist + candidate filter gain the i32 8/16-bit variants. (Skip gate already treated integer partial-width ops as verifiable.)

### Validation
- `test_inline_partial_width_seam_fully_dissolves`; #159 guard reworked to use `i32.div_s` as the un-modelable writer. **391 lib tests pass.**
- gale `seam16`: both `wr16`+`rd16` inline (0 calls), oracle bit-for-bit incl. **v=70000 → -127** (catches sign-ext/mask bugs).
- `flight_seam`: `controller_step` inlines; `filter_step` now blocked only by `i32.div_s` (separate). Integration: only the 7 #150 failures.

### Known-red gates (pre-existing)
- Rocq Formal Proofs (upstream); Test/Coverage (the 7 #150 failures).

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)