### PR TITLE
feat(verify): inline callees with integer division (closes #163, v1.1.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to LOOM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.10] - 2026-06-02
+
+**Optimization release: inline callees with integer division (#163) — full
+flight_algo dissolution.** By-body inline modeling now handles integer
+division/remainder (`i32`/`i64` `div_s`/`div_u`/`rem_s`/`rem_u`), so a callee
+that divides (e.g. `filter_step`'s EWMA `/1000`) inlines and verifies. With
+this, gale's real `flight_algo` seam collapses to a single function: every
+co-inlined callee (reads, writes, partial-width, division) now dissolves.
+
+### Added
+
+- **Integer division/remainder modeling** in by-body inlining. `div_s`→`bvsdiv`,
+  `div_u`→`bvudiv`, `rem_s`→`bvsrem`, `rem_u`→`bvurem` — the same encoding the
+  main encoder already used, added to `encode_simple_instruction` so the by-body
+  modeler and the inlined body produce identical expressions. Added to the
+  by-body whitelist (`is_inline_modelable_instr`) and the inline candidate
+  filter (`function_inline_modelable`).
+- **Soundness for inlining:** `bvsdiv` truncates toward zero, matching WASM
+  `div_s`. Z3's div is *total* (defined at divide-by-zero), whereas WASM traps
+  on `b==0` and on `INT_MIN / -1`; this is sound for the inline transformation
+  because the *same* division appears in both the original modeled call and the
+  inlined body, so any real trap occurs identically on both sides — the
+  transformation preserves trap behavior regardless of the model. (The whitelist
+  governs inlining only.)
+
+### Validation
+
+- New `test_inline_division_seam_fully_dissolves` (a `/1000` reader seam → 0
+  calls). 392 lib tests pass; integration unchanged (only the 7 #150 failures).
+- gale's `divseam` fully dissolves (0 calls); wasmtime oracle matches native
+  bit-for-bit incl. the sign/truncate-toward-zero vectors **-1500 → -3**,
+  **499 → 0**, **-499 → 0**, **1000000 → 2000** (a floor-division or wrong-sign
+  model would diverge there).
+- **`flight_seam` now fully dissolves: 0 calls** — both `filter_step` and
+  `controller_step` inline; gale's real `flight_algo` collapses to one function.
+- The #159 regression guard's "un-modelable writer" moved to `f32.store`
+  (float memory ops stay outside the integer model; `store16`/`div_s` are now
+  modelable).
+
+### Note
+
+This completes through-memory inline verification for this class
+(reads → writes → partial-width → division). The on-silicon composed-algo
+measurement additionally needs the fp/linear-memory-vs-native-pointer ABI
+trampoline on hardware (gale's side) and remains gated on synth#210; the
+loom-level full dissolution and the wasmtime/unicorn proof stand on their own.
+
 ## [1.1.9] - 2026-06-02
 
 **Optimization release: inline callees with partial-width loads/stores (#161).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.9"
+version = "1.1.10"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -13457,6 +13457,14 @@ pub mod optimize {
                     | Instruction::I64Shl
                     | Instruction::I64ShrS
                     | Instruction::I64ShrU
+                    | Instruction::I32DivS
+                    | Instruction::I32DivU
+                    | Instruction::I32RemS
+                    | Instruction::I32RemU
+                    | Instruction::I64DivS
+                    | Instruction::I64DivU
+                    | Instruction::I64RemS
+                    | Instruction::I64RemU
                     | Instruction::I32Eq
                     | Instruction::I32Ne
                     | Instruction::I32LtS
@@ -18746,18 +18754,20 @@ mod tests {
     #[test]
     fn test_inline_reader_after_unmodelable_writer() {
         // loom#159 REGRESSION GUARD. A full-width READER (`rd`) following an
-        // UN-MODELABLE WRITER (`nm`, uses `i32.div_s` which the verifier can't
-        // model — div may trap). The reader must still inline (proven against
-        // the writer's havoc'd memory) while the un-modelable writer stays an
-        // opaque call. v1.1.7 regressed this: a non-modelable callee became a
-        // candidate (the filter looked only at writes), got inlined, diverged
-        // from the original's havoc → false revert that ALSO killed `rd`'s
-        // inline. The fix gates candidates on FULL inline-modelability.
-        // (NB: as of loom#161, partial-width `i32.store16` IS modelable and
-        // would inline — so this guard uses `i32.div_s` to stay un-modelable.)
+        // UN-MODELABLE WRITER (`nm`, uses `f32.store` — float memory ops have no
+        // Z3 model). The reader must still inline (proven against the writer's
+        // havoc'd memory) while the un-modelable writer stays an opaque call.
+        // v1.1.7 regressed this: a non-modelable callee became a candidate (the
+        // filter looked only at writes), got inlined, diverged from the
+        // original's havoc → false revert that ALSO killed `rd`'s inline. The
+        // fix gates candidates on FULL inline-modelability.
+        // (NB: this guard's "un-modelable" op has had to move as the capability
+        // series advanced — store16 became modelable in #161, div_s in #163.
+        // Float memory ops are anchored outside the integer model, so `f32.store`
+        // is a durable choice.)
         let wat = r#"(module
             (memory 1)
-            (func $seam (export "seam") (param i32 i32) (result i32)
+            (func $seam (export "seam") (param i32 f32) (result i32)
                 local.get 0
                 local.get 1
                 call $nm
@@ -18766,12 +18776,10 @@ mod tests {
             (func $rd (param i32) (result i32)
                 local.get 0
                 i32.load)
-            (func $nm (param i32 i32)
+            (func $nm (param i32 f32)
                 local.get 0
                 local.get 1
-                local.get 1
-                i32.div_s
-                i32.store)
+                f32.store)
         )"#;
         let mut module = parse::parse_wat(wat).expect("parse");
         optimize::inline_functions(&mut module).expect("must not panic");
@@ -18793,7 +18801,55 @@ mod tests {
         );
         assert_eq!(
             pw_calls, 1,
-            "un-modelable writer (i32.div_s) must stay an opaque call"
+            "un-modelable writer (f32.store) must stay an opaque call"
+        );
+        let wasm_bytes = encode::encode_wasm(&module).expect("encode");
+        wasmparser::validate(&wasm_bytes).expect("output validates");
+    }
+
+    #[test]
+    fn test_inline_division_seam_fully_dissolves() {
+        // loom#163: a seam whose reader divides (`rdd`: (a+b)/1000, i32.div_s,
+        // truncate toward zero). Integer div/rem are now by-body modelable via
+        // Z3 bvsdiv/bvudiv/bvsrem/bvurem, so writer `wrd` AND reader `rdd` both
+        // inline → the seam fully dissolves (0 calls), proven. This is the final
+        // through-memory inlining capability (reads → writes → partial-width →
+        // division) — it collapses gale's real flight_algo to one function.
+        // Mirrors gale's divseam.
+        let wat = r#"(module
+            (memory 1)
+            (func $seam (export "seam") (param i32 i32) (result i32)
+                local.get 0
+                local.get 1
+                call $wrd
+                local.get 0
+                call $rdd)
+            (func $rdd (param i32) (result i32)
+                local.get 0
+                i32.load offset=4
+                local.get 0
+                i32.load
+                i32.add
+                i32.const 1000
+                i32.div_s)
+            (func $wrd (param i32 i32)
+                local.get 0
+                local.get 1
+                i32.store offset=4
+                local.get 0
+                local.get 1
+                i32.store)
+        )"#;
+        let mut module = parse::parse_wat(wat).expect("parse");
+        optimize::inline_functions(&mut module).expect("must not panic");
+        let calls = module.functions[0]
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, Instruction::Call(_)))
+            .count();
+        assert_eq!(
+            calls, 0,
+            "division seam must fully dissolve: both i32.store writer and i32.div_s reader inline (#163)"
         );
         let wasm_bytes = encode::encode_wasm(&module).expect("encode");
         wasmparser::validate(&wasm_bytes).expect("output validates");

--- a/loom-core/src/verify.rs
+++ b/loom-core/src/verify.rs
@@ -250,12 +250,16 @@ fn is_inline_modelable_instr(instr: &Instruction) -> bool {
         | I32Load8S { .. } | I32Load8U { .. }
         | I32Load16S { .. } | I32Load16U { .. }
         | I32Store8 { .. } | I32Store16 { .. }
-        // i32 arithmetic / bitwise (total: no div/rem)
+        // i32 arithmetic / bitwise
         | I32Add | I32Sub | I32Mul | I32And | I32Or | I32Xor
         | I32Shl | I32ShrS | I32ShrU
-        // i64 arithmetic / bitwise (total: no div/rem)
+        // i64 arithmetic / bitwise
         | I64Add | I64Sub | I64Mul | I64And | I64Or | I64Xor
         | I64Shl | I64ShrS | I64ShrU
+        // integer division/remainder (loom#163) — bvsdiv/bvudiv/bvsrem/bvurem;
+        // trap-on-zero preserved (same op both sides), sound for inlining
+        | I32DivS | I32DivU | I32RemS | I32RemU
+        | I64DivS | I64DivU | I64RemS | I64RemU
         // i32 comparisons
         | I32Eq | I32Ne | I32LtS | I32LtU | I32GtS | I32GtU
         | I32LeS | I32LeU | I32GeS | I32GeU | I32Eqz
@@ -6658,6 +6662,50 @@ fn encode_simple_instruction(
             let lhs = stack.pop().unwrap();
             let (lhs, rhs) = match_bv_widths(lhs, rhs);
             stack.push(lhs.bvlshr(&rhs));
+        }
+        // loom#163: integer division/remainder. Modeled via Z3 bvsdiv/bvudiv/
+        // bvsrem/bvurem — bvsdiv truncates toward zero, matching WASM div_s.
+        // SOUNDNESS for inlining: the same division appears in BOTH the original
+        // modeled call and the optimized inlined body, so they encode to the
+        // identical (total) expression → equal; and any real div-by-zero /
+        // INT_MIN÷-1 trap occurs identically on both sides, so the inline
+        // transformation preserves trap behavior regardless of the model. These
+        // mirror the main encoder's arms exactly.
+        Instruction::I32DivS | Instruction::I64DivS => {
+            if stack.len() < 2 {
+                return Err(anyhow!("Stack underflow"));
+            }
+            let rhs = stack.pop().unwrap();
+            let lhs = stack.pop().unwrap();
+            let (lhs, rhs) = match_bv_widths(lhs, rhs);
+            stack.push(lhs.bvsdiv(&rhs));
+        }
+        Instruction::I32DivU | Instruction::I64DivU => {
+            if stack.len() < 2 {
+                return Err(anyhow!("Stack underflow"));
+            }
+            let rhs = stack.pop().unwrap();
+            let lhs = stack.pop().unwrap();
+            let (lhs, rhs) = match_bv_widths(lhs, rhs);
+            stack.push(lhs.bvudiv(&rhs));
+        }
+        Instruction::I32RemS | Instruction::I64RemS => {
+            if stack.len() < 2 {
+                return Err(anyhow!("Stack underflow"));
+            }
+            let rhs = stack.pop().unwrap();
+            let lhs = stack.pop().unwrap();
+            let (lhs, rhs) = match_bv_widths(lhs, rhs);
+            stack.push(lhs.bvsrem(&rhs));
+        }
+        Instruction::I32RemU | Instruction::I64RemU => {
+            if stack.len() < 2 {
+                return Err(anyhow!("Stack underflow"));
+            }
+            let rhs = stack.pop().unwrap();
+            let lhs = stack.pop().unwrap();
+            let (lhs, rhs) = match_bv_widths(lhs, rhs);
+            stack.push(lhs.bvurem(&rhs));
         }
 
         // i32 comparisons


### PR DESCRIPTION
## gale #163 — integer-division inlining → full flight_algo dissolution

By-body inline modeling now handles integer division/remainder (`i32`/`i64` `div_s`/`div_u`/`rem_s`/`rem_u`). **gale's real `flight_algo` seam now collapses to a single function** — every co-inlined callee (reads #155 → writes #157 → partial-width #161 → division #163) inlines.

### How
`div_s`→`bvsdiv`, `div_u`→`bvudiv`, `rem_s`→`bvsrem`, `rem_u`→`bvurem` in `encode_simple_instruction` — the same encoding the main encoder already used, so the by-body model and the inlined body are identical expressions. Added to the whitelist + candidate filter.

### Soundness
`bvsdiv` truncates toward zero (matches WASM `div_s`). Z3 div is *total* while WASM traps on `b==0` / `INT_MIN÷-1` — sound for inlining because the **same division** appears in both the original modeled call and the inlined body, so any real trap occurs identically on both sides; the transformation preserves trap behavior regardless of the model.

### Validation
- `test_inline_division_seam_fully_dissolves`; #159 guard's un-modelable writer moved to `f32.store`. **392 lib tests pass.**
- gale `divseam`: `wrd`+`rdd` inline → 0 calls; oracle bit-for-bit incl. truncate-toward-zero sign vectors **-1500→-3, 499→0, -499→0, 1000000→2000**.
- **`flight_seam` fully dissolves: 0 calls** (filter_step + controller_step both inline).
- Integration: only the 7 pre-existing #150 failures.

### Known-red gates (pre-existing)
- Rocq Formal Proofs (upstream); Test/Coverage (the 7 #150 failures).

Closes #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)