### PR TITLE
fix(licm/dce): precise control-flow guards restore LICM/DCE (closes #150)

### DIFF
--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -6820,26 +6820,65 @@ pub mod optimize {
             for instr in instrs {
                 match instr {
                     Instruction::BrIf { .. } | Instruction::BrTable { .. } => return true,
-                    Instruction::Block { body, .. } | Instruction::Loop { body, .. } => {
-                        if scan(body) {
-                            return true;
-                        }
+                    Instruction::Block { body, .. } | Instruction::Loop { body, .. }
+                        if scan(body) =>
+                    {
+                        return true;
                     }
                     Instruction::If {
                         then_body,
                         else_body,
                         ..
-                    } => {
-                        if scan(then_body) || scan(else_body) {
-                            return true;
-                        }
-                    }
+                    } if scan(then_body) || scan(else_body) => return true,
                     _ => {}
                 }
             }
             false
         }
         scan(&func.instructions)
+    }
+
+    /// loom#150 — LICM-specific control-flow guard, narrower than
+    /// [`has_dataflow_unsafe_control_flow`]. The blunt shared guard treats *any*
+    /// `BrIf` as unsafe — but every loop's back-edge is a `br_if`, so it
+    /// disabled LICM for essentially all real loops. This guard permits exactly
+    /// one extra shape: a back-edge branch (`Br(0)`/`BrIf(0)`) that is the LAST
+    /// instruction **directly** in a loop body. Such a branch only decides
+    /// whether to re-iterate; every instruction before it runs unconditionally
+    /// on each iteration, and (in a function whose only branch is this
+    /// back-edge) the loop is reached unconditionally — so hoisting a
+    /// loop-invariant value to the pre-header is sound (same reachability as
+    /// iteration 1, identical value every iteration). Any other branch —
+    /// mid-body `BrIf`, `BrTable`, a branch to an outer label, or a non-tail
+    /// `Br`/`Return` — could skip the hoisted op on some path, so it stays
+    /// unsafe (REQ-5). `verify_or_revert` remains as defense-in-depth.
+    fn licm_unverifiable_control_flow(func: &Function) -> bool {
+        fn scan(instrs: &[Instruction], in_loop_body: bool) -> bool {
+            let n = instrs.len();
+            for (i, instr) in instrs.iter().enumerate() {
+                let is_last = i + 1 == n;
+                match instr {
+                    // Back-edge as the loop-body terminator: safe (see above).
+                    Instruction::BrIf(0) | Instruction::Br(0) if in_loop_body && is_last => {}
+                    // Any other conditional / multi-way branch: unsafe.
+                    Instruction::BrIf { .. } | Instruction::BrTable { .. } => return true,
+                    // Non-tail unconditional branch / return creates an
+                    // early-exit path: unsafe (tail position is just the
+                    // function/loop ending).
+                    Instruction::Br(_) | Instruction::Return if !is_last => return true,
+                    Instruction::Loop { body, .. } if scan(body, true) => return true,
+                    Instruction::Block { body, .. } if scan(body, false) => return true,
+                    Instruction::If {
+                        then_body,
+                        else_body,
+                        ..
+                    } if scan(then_body, false) || scan(else_body, false) => return true,
+                    _ => {}
+                }
+            }
+            false
+        }
+        scan(&func.instructions, false)
     }
 
     /// Optimize a module by applying constant folding and other optimizations
@@ -9914,12 +9953,14 @@ pub mod optimize {
                 continue;
             }
 
-            // Skip functions with BrIf/BrTable: the Z3 verifier is path-insensitive
-            // across these branches (top-of-stack-only equivalence model), so
-            // hoisting code across them can pass verification while being unsound
-            // on paths that branch out before the hoisted op's original location.
-            // Conservative-over-fast (REQ-5).
-            if has_dataflow_unsafe_control_flow(func) {
+            // loom#150: the blunt guard skips any function with a BrIf — but a
+            // loop's back-edge IS a br_if, so that disabled LICM for every real
+            // loop. The LICM-specific guard permits a tail-position back-edge
+            // (Br(0)/BrIf(0) as the last instruction directly in a loop body),
+            // where hoisting an invariant value to the pre-header is sound, while
+            // still bailing on any branch that could skip the hoisted op on some
+            // path. verify_or_revert below is defense-in-depth (REQ-5).
+            if licm_unverifiable_control_flow(func) {
                 continue;
             }
 

--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -6805,6 +6805,43 @@ pub mod optimize {
         false
     }
 
+    /// loom#150 — DCE-specific control-flow guard, narrower than
+    /// [`has_dataflow_unsafe_control_flow`]. Dead-code elimination here only
+    /// ever *deletes instructions that follow an unconditional terminator*
+    /// (`Return`/`Unreachable`) within a block — that code is unreachable, so
+    /// removing it is sound regardless of where the terminator sits (the blunt
+    /// shared guard wrongly skips a function merely because a `return` is not in
+    /// tail position). We still bail on *conditional* branches (`BrIf`/
+    /// `BrTable`): there, code after the branch is reachable and the
+    /// path-insensitive translation validator can't be trusted to model it, so
+    /// we stay conservative-over-fast (REQ-5).
+    fn dce_unverifiable_control_flow(func: &Function) -> bool {
+        fn scan(instrs: &[Instruction]) -> bool {
+            for instr in instrs {
+                match instr {
+                    Instruction::BrIf { .. } | Instruction::BrTable { .. } => return true,
+                    Instruction::Block { body, .. } | Instruction::Loop { body, .. } => {
+                        if scan(body) {
+                            return true;
+                        }
+                    }
+                    Instruction::If {
+                        then_body,
+                        else_body,
+                        ..
+                    } => {
+                        if scan(then_body) || scan(else_body) {
+                            return true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            false
+        }
+        scan(&func.instructions)
+    }
+
     /// Optimize a module by applying constant folding and other optimizations
     /// Phase 12: Uses ISLE with dataflow-aware environment tracking
     pub fn optimize_module(module: &mut Module) -> Result<()> {
@@ -10628,9 +10665,11 @@ pub mod optimize {
                 continue;
             }
 
-            // Skip early-exit functions — branch-removal can restructure
-            // control flow across guard boundaries (REQ-5).
-            if has_dataflow_unsafe_control_flow(func) {
+            // loom#150: DCE only deletes code after an unconditional terminator
+            // (sound regardless of where the terminator sits), so the narrower
+            // DCE guard permits non-tail Return/Br while still bailing on
+            // conditional branches the validator can't model (REQ-5).
+            if dce_unverifiable_control_flow(func) {
                 continue;
             }
 

--- a/loom-core/tests/optimization_tests.rs
+++ b/loom-core/tests/optimization_tests.rs
@@ -1815,6 +1815,59 @@ fn test_licm_global_not_hoisted_when_modified() {
     );
 }
 
+#[test]
+fn test_licm_no_hoist_past_midbody_branch() {
+    // loom#150 PRECISION GUARD. LICM was re-enabled for loops whose only branch
+    // is a tail-position back-edge `br_if` (sound: every instruction before it
+    // runs each iteration). This test pins the boundary: a `br_if` in the
+    // MIDDLE of the loop body (an early-exit, not the back-edge) must still
+    // disable hoisting, because on the exit path the invariant's original
+    // location may never be reached. The function must be skipped entirely —
+    // nothing hoisted.
+    let input = r#"
+        (module
+            (func (param $x i32) (param $y i32) (result i32)
+                (local $sum i32)
+                (local $inv i32)
+                (block $exit
+                    (loop $loop
+                        ;; invariant computation
+                        (local.set $inv (i32.add (local.get $x) (local.get $y)))
+                        ;; MID-BODY early-exit (breaks out of $exit) — NOT a back-edge
+                        (br_if $exit (local.get $x))
+                        (local.set $sum (i32.add (local.get $sum) (local.get $inv)))
+                        (br_if $loop (i32.const 0))
+                    )
+                )
+                (local.get $sum)
+            )
+        )
+    "#;
+
+    fn count_loop_body_instrs(instrs: &[loom_core::Instruction]) -> usize {
+        use loom_core::Instruction;
+        for instr in instrs {
+            match instr {
+                Instruction::Loop { body, .. } => return body.len(),
+                Instruction::Block { body, .. } => return count_loop_body_instrs(body),
+                _ => {}
+            }
+        }
+        0
+    }
+
+    let before =
+        count_loop_body_instrs(&parse::parse_wat(input).unwrap().functions[0].instructions);
+    let mut module = parse::parse_wat(input).unwrap();
+    optimize::loop_invariant_code_motion(&mut module).unwrap();
+    let after = count_loop_body_instrs(&module.functions[0].instructions);
+
+    assert_eq!(
+        after, before,
+        "LICM must NOT hoist out of a loop with a mid-body early-exit branch (#150 soundness boundary)"
+    );
+}
+
 // Remove Unused Branches Tests
 
 #[test]


### PR DESCRIPTION
## #150 — the recurring red Test-matrix gate

7 integration tests (5 LICM + 2 DCE) failed because the shared guard `has_dataflow_unsafe_control_flow` is a blunt over-approximation: **any `br_if` ⇒ skip**. But every loop's back-edge is a `br_if`, and DCE's terminators aren't always in tail position — so LICM was disabled for essentially all real loops and DCE for any non-tail `return`. These have been admin-merged *past* on every release v1.1.6–v1.1.10.

## Fix — two purpose-built, narrower guards (shared guard untouched for its other 8 callers)

**DCE (`dce_unverifiable_control_flow`):** `remove_dead_code` only deletes instructions *after* an unconditional terminator (`Return`/`Unreachable`) — unreachable, so sound regardless of where the terminator sits. New guard permits non-tail `Return`/`Br` but still bails on conditional `BrIf`/`BrTable`.

**LICM (`licm_unverifiable_control_flow`):** permits exactly one extra shape — a back-edge `Br(0)`/`BrIf(0)` as the **last** instruction directly in a loop body. Soundness: it only decides re-iteration; every instruction before it runs each iteration, the body runs ≥1× once entered, and (in a function whose only branch is this back-edge) the loop is reached unconditionally — so hoisting an invariant to the pre-header has identical reachability to iteration 1 and the same value every iteration. Any mid-body `BrIf`, `BrTable`, outer-target branch, or non-tail `Br`/`Return` stays unsafe. `verify_or_revert` remains as defense-in-depth (REQ-5).

## Validation
- All 7 previously-failing tests pass; **integration 85/0, lib 392/0**.
- Negative soundness guards stay green: `no_hoist_modified_local`, `global_not_hoisted_when_modified`.
- New `test_licm_no_hoist_past_midbody_branch` pins the precision boundary (a mid-body early-exit must NOT hoist).
- Clippy clean.

## Known-red (pre-existing, unrelated)
- Rocq Formal Proofs (upstream toolchain).

Closes #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)