### PR TITLE
fix(release): exclude rayon on wasm32 so the WASM build links — restores release binaries (#142)

### DIFF
--- a/loom-core/Cargo.toml
+++ b/loom-core/Cargo.toml
@@ -32,6 +32,11 @@ leb128 = "0.2"
 # Parallel island-model optimization (v1.0.4 PR-islands, issue #71).
 # Scoped to loom-core only — the dependency boundary stays tight; CLI does
 # not depend on rayon, it just dispatches into the per-island entry point.
+# Excluded on wasm32: rayon's thread pool needs pthread, which the
+# single-threaded wasm32-wasip2 target can't link (#142 — the missing
+# release binaries traced to this link failure). islands.rs falls back to a
+# sequential run there; the deterministic tie-break makes it bit-identical.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rayon = "1"
 
 [dev-dependencies]

--- a/loom-core/src/islands.rs
+++ b/loom-core/src/islands.rs
@@ -38,6 +38,9 @@
 
 use crate::Module;
 use anyhow::{Result, anyhow};
+// rayon is excluded on wasm32 (no pthread); islands run sequentially there.
+// The deterministic tie-break (see below) makes the result identical. (#142)
+#[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 
 /// Configuration for a single optimization island.
@@ -284,8 +287,17 @@ pub fn optimize_module_islands(module: &Module, configs: &[IslandConfig]) -> Res
     // `par_iter()` here yields `Result<IslandResult>`; we keep both Ok and
     // Err so we can preserve per-island failure messages for the no-winner
     // case below.
+    #[cfg(not(target_arch = "wasm32"))]
     let results: Vec<Result<IslandResult>> = configs
         .par_iter()
+        .map(|cfg| run_one_island(module, cfg))
+        .collect();
+    // wasm32 has no thread pool — run the same islands sequentially. The
+    // deterministic tie-break below makes the winner identical to the
+    // parallel path. (#142)
+    #[cfg(target_arch = "wasm32")]
+    let results: Vec<Result<IslandResult>> = configs
+        .iter()
         .map(|cfg| run_one_island(module, cfg))
         .collect();
 
@@ -356,14 +368,25 @@ pub fn measure_island_sizes(
     module: &Module,
     configs: &[IslandConfig],
 ) -> Vec<(String, Result<usize>)> {
-    configs
+    #[cfg(not(target_arch = "wasm32"))]
+    let out = configs
         .par_iter()
         .map(|cfg| {
             let name = cfg.name.to_string();
             let result = run_one_island(module, cfg).map(|r| r.encoded.len());
             (name, result)
         })
-        .collect()
+        .collect();
+    #[cfg(target_arch = "wasm32")]
+    let out = configs
+        .iter()
+        .map(|cfg| {
+            let name = cfg.name.to_string();
+            let result = run_one_island(module, cfg).map(|r| r.encoded.len());
+            (name, result)
+        })
+        .collect();
+    out
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Root cause of the missing release binaries (#142)

Not a lost upload step — a **failing WASM build**. Every release v1.1.5–v1.1.10 shipped **zero assets** because:

- `Build WASM (wasm32-wasip2)` **fails** at link, and
- `Create Release` has `needs: [build-native, build-wasm]`, so it's **skipped** — the native binaries that built fine never get uploaded.

The WASM link error:
```
rust-lld: undefined symbol: __wasi_init_tp / pthread_create / pthread_detach
error: could not compile `loom-cli`
```

**Source:** loom-core depends on `rayon` (islands.rs — the opt-in #71 island-model parallel pass-ordering). rayon's thread pool needs pthread, absent on the single-threaded `wasm32-wasip2` target; the threaded startup also drags in `__wasi_init_tp`.

## Fix
- `rayon` → `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`.
- islands.rs: sequential fallback on wasm (`iter()` vs `par_iter()`).
- The island tie-break is **deterministic across interleavings** (`test_islands_deterministic_tiebreak`, `test_islands_baseline_matches_serial`), so sequential ≡ parallel — **behavior frozen**.

## Verified
- loom-core compiles for `wasm32-wasip2` (rayon excluded, islands wasm path valid).
- Native islands tests **6/6 green** (the `par_iter` path is byte-identical to before).
- ⚠️ The full release WASM link (z3 built via wasi-sdk in CI) + asset upload can only be confirmed by a release run — **do not merge until a `workflow_dispatch` dry-run or the next release shows `build-wasm` green + assets uploaded.**

## Scope
This is the **primary** #142 fix (binaries shipping at all). The **secondary** unified-artifact-standard rewrite is PR #143 (`chore/standardize-release-yml`) — orthogonal to this loom-core change; both are needed.

Refs #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)