### PR TITLE
docs(ci): document rocq-proofs gating rationale + plan (refs #169)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,15 @@ jobs:
     # Stays on ubuntu-latest: requires Nix + Bazel; both are out-of-scope for
     # smithy phase 1 (see migration playbook "What's currently out of scope").
     runs-on: ubuntu-latest
+    # continue-on-error is TEMPORARY, not the intended end state (loom#169).
+    # The job is currently red because of the upstream rules_rocq_rust toolchain
+    # breakage (fixes in flight: #141 / #139 bump rules_rocq_rust). Making it
+    # gating while red would block every merge. Plan to close loom#169:
+    #   1. land the rules_rocq_rust bump (#141/#139) so this job goes green;
+    #   2. then REMOVE continue-on-error so a proof regression blocks merge;
+    #   3. separately discharge the proofs' remaining Admitted/Axiom (criterion
+    #      3 "complete") — gating catches regressions in the proven parts but
+    #      does not by itself close those gaps.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Addresses #169 (make rocq-proofs gating) — the part that's safe to do **now**.

## Why not just remove `continue-on-error`?
The `rocq-proofs` job is **currently red on main**: it runs `bazel build/test //proofs/...` and fails on the upstream **rules_rocq_rust** toolchain breakage (fixes in flight: #141 / #139). Removing `continue-on-error` while red would turn the whole CI gate red and **block every merge**. So the naive fix is destructive.

The proofs also carry **10 `Admitted` + 19 `Axiom`**, so the issue's criterion 3 ("complete — no axioms standing in for proofs") is separate, larger work.

## What this does
The issue says a deviation should be *documented if there's a reason*. There is — so this documents it inline on the job, with the explicit ordered plan to actually close #169:
1. land the rules_rocq_rust bump (#141/#139) → job goes green;
2. **then** remove `continue-on-error` → gating;
3. discharge the `Admitted`/`Axiom` separately.

Comment-only; no behavior change; does **not** remove `continue-on-error`.

Refs #169. (Also: #141 and #139 are redundant — both bump rules_rocq_rust — one should be picked to unblock step 1.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)