### PR TITLE
fix(docs): un-indent egraph heading — fixes failing doctest reddening the Test job

### DIFF
--- a/loom-core/src/egraph.rs
+++ b/loom-core/src/egraph.rs
@@ -9,8 +9,7 @@
 //! substrate — which is exactly what LOOM's "provably correct" mission
 //! requires.
 //!
-//! ## Scope (v1.0.3 substrate + v1.0.4 Track C rewrite engine
-//!     + v1.1.0 Track C widening)
+//! ## Scope (v1.0.3 substrate + v1.0.4 Track C rewrite engine + v1.1.0 Track C widening)
 //!
 //! This module ships:
 //!


### PR DESCRIPTION
## What
The egraph module-doc `## Scope` heading wrapped onto a 4-space-indented second line, which rustdoc compiles as an indented-code-block doctest:
```
//! ## Scope (v1.0.3 substrate + v1.0.4 Track C rewrite engine
//!     + v1.1.0 Track C widening)   <-- 4-space indent → "doctest"
```
`+ v1.1.0 Track C widening)` is invalid Rust → `unexpected closing delimiter` → `cargo test --all` fails → **CI Test job red on all platforms** (surfaced on macos; ubuntu/windows fail-fast cancelled).

## Fix
Collapse the heading to one line. **Doc-only, no behavior change.**

## Verified
`cargo test -p loom-core --doc` now green (was 1 failed). Audited for other 4-space-indented doc lines — the rest are inside fenced/list contexts rustdoc doesn't compile.

Note: not a regression from recent work — #150's unit/integration tests were already green; this separate doctest was the actual Test-job red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)