### PR TITLE
fix(component): skip indirect-call-table modules — stop silent miscompile (closes #196, v1.1.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to LOOM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.12] - 2026-06-10
+
+**CRITICAL bug fix: stop silently miscompiling modules with indirect-call
+tables (#196).** v1.1.11's #172 encoding fix made falcon's core module 0
+*encode* validly — which unmasked a worse, pre-existing defect: loom's
+optimization of a module with a function-referencing element segment produces
+**valid-but-wrong** code (a scrambled / stale `call_indirect` table, and
+further parse→re-encode corruption). It passes `wasm-tools validate` AND loom
+`--verify` (both structural) but flies wrong — falcon's SIL gate went
+`run-position-hold` 0.13 m → **593.8 m**. v1.1.10 was *accidentally* safe (it
+fell back to original bytes); v1.1.11 removed that accident.
+
+### Fixed (correctness — flight-critical)
+
+- **Skip optimization of any core module with a function-referencing element
+  segment**, keeping the original bytes, in both the component path
+  (`optimize_core_module`) and the standalone path (`optimize_module`). loom
+  cannot currently verify such a module is optimized *behaviorally* correctly —
+  the fused pass does not remap the indirect-call table consistently across its
+  sub-passes, and structural verification cannot detect a wrong-but-valid table.
+  This restores v1.1.10's safe behavior *deliberately*. (#172's element
+  segment-count fix is retained; it was real, just insufficient.)
+
+### Validation (behavioral, not just structural)
+
+- gale's exact artifact (`falcon-flight-v1.34.wasm`): optimized output now
+  matches the original bit-for-bit on `run-stabilization` (0.023399856) and
+  `run-position-hold` (0.1317415) under wasmtime, and validates. Was 0.329 /
+  593.79 on v1.1.11.
+- New regression tests: `element_section_references_functions` detection +
+  per-slot element-remap identity (#196). 395 lib + 85 integration pass.
+
+### Known limitation / next step
+
+- Modules with indirect-call tables are now *unoptimized* (safe). Re-enabling
+  them is gated on a **behavioral differential** in loom (run exports before/
+  after and compare) — structural `--verify` is insufficient, as #196 proved.
+
 ## [1.1.11] - 2026-06-10
 
 **Bug fix: fused pass no longer invalidates core modules with element segments (#172).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.11"
+version = "1.1.12"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/loom-core/src/component_optimizer.rs
+++ b/loom-core/src/component_optimizer.rs
@@ -211,6 +211,27 @@ fn optimize_core_module(module_bytes: &[u8]) -> Result<Vec<u8>> {
     // Parse the module
     let mut module = crate::parse::parse_wasm(module_bytes)?;
 
+    // #196 (CRITICAL — flight-control silent miscompile). A core module with a
+    // function-referencing element segment (a populated `call_indirect` table)
+    // is one loom cannot currently optimize with *behavioral* certainty: the
+    // fused pass's multi-sub-pass function-index changes are not remapped into
+    // the table consistently, and the parse→re-encode round-trip has further
+    // latent corruption on such modules — all of which pass `wasm-tools
+    // validate` AND loom `--verify` (both structural) while flying wrong
+    // (v1.1.11 on falcon: SIL gate 0.13 m → 593.8 m). v1.1.10 was accidentally
+    // safe here (it fell back to the original bytes); we now do so DELIBERATELY:
+    // keep the original module untouched rather than ship a valid-but-wrong
+    // optimization. Correctness over optimization (LOOM's prime directive).
+    // Re-enabling optimization for these modules is gated on a behavioral
+    // differential (run exports before/after and compare) — see #196.
+    if crate::fused_optimizer::element_section_references_functions(&module) {
+        eprintln!(
+            "  Skipped optimization: module has a function-referencing element table \
+             (indirect-call dispatch); keeping original bytes pending a behavioral gate (#196)"
+        );
+        return Ok(module_bytes.to_vec());
+    }
+
     // Phase 0: Fused component optimizations (runs before standard pipeline)
     // These passes target artifacts from component fusion (meld):
     // - Adapter trampolines that just forward calls

--- a/loom-core/src/fused_optimizer.rs
+++ b/loom-core/src/fused_optimizer.rs
@@ -2370,6 +2370,42 @@ fn remove_trivial_calls_from_block(
 /// Uses `wasm_encoder` to rebuild the element section with updated function indices.
 /// Only handles segments with direct function indices (not expression-based segments).
 /// Falls back to keeping original bytes if expression-based segments are present.
+/// True if the module has an element segment that references any function — a
+/// populated indirect-call table. #196: loom currently cannot guarantee a core
+/// module with such a table is optimized *behaviorally* correctly (its
+/// structural verification can't see a scrambled / stale function-pointer
+/// table or other round-trip corruption), so callers skip optimization for
+/// these modules and keep the original bytes. Anything that can't be parsed as
+/// a plain empty section is treated conservatively as "yes, references
+/// functions" so we err toward not optimizing.
+pub(crate) fn element_section_references_functions(module: &Module) -> bool {
+    use wasmparser::{BinaryReader, ElementItems, FromReader};
+    let bytes = match &module.element_section_bytes {
+        Some(b) => b,
+        None => return false,
+    };
+    let mut reader = BinaryReader::new(bytes, 0);
+    let count = match reader.read_var_u32() {
+        Ok(c) => c,
+        Err(_) => return true, // unparseable → don't risk touching the module
+    };
+    for _ in 0..count {
+        match wasmparser::Element::from_reader(&mut reader) {
+            Ok(elem) => match elem.items {
+                ElementItems::Functions(funcs) => {
+                    if funcs.count() > 0 {
+                        return true;
+                    }
+                }
+                // Expression lists may hold `ref.func`; treat as referencing.
+                ElementItems::Expressions(_, _) => return true,
+            },
+            Err(_) => return true, // unparseable → conservative
+        }
+    }
+    false
+}
+
 fn remap_element_section_refs(module: &mut Module, remap: &HashMap<u32, u32>) -> Result<()> {
     use wasmparser::{BinaryReader, ElementItems, ElementKind, FromReader};
 
@@ -5974,5 +6010,75 @@ mod tests {
                 _ => panic!("expected a function-index element list"),
             }
         }
+    }
+
+    /// #196 regression (CRITICAL): the remapped table must hold the SAME
+    /// functions in the SAME slot order — each slot's funcref mapped through
+    /// old→new, in place. v1.1.11 produced a valid-but-wrong (scrambled) table
+    /// that `validate`/`--verify` could not detect; only behavior caught it.
+    /// This asserts per-slot func identity under a NON-identity remap.
+    #[test]
+    fn test_remap_element_section_preserves_per_slot_function() {
+        use std::collections::HashMap;
+        let mut module = empty_module();
+
+        // One active segment listing func indices [4, 2, 7, 9] (deliberately
+        // unsorted, to catch any reordering).
+        let payload: Vec<u8> = vec![
+            0x01, // segment count = 1
+            0x00, // flags: active, table 0
+            0x41, 0x00, 0x0b, // offset: i32.const 0, end
+            0x04, // 4 functions
+            0x04, 0x02, 0x07, 0x09, // func indices
+        ];
+        module.element_section_bytes = Some(payload);
+
+        // Non-identity remap, as produced by dead-function removal.
+        let remap: HashMap<u32, u32> = [(4, 3), (2, 2), (7, 6), (9, 8)].into_iter().collect();
+        remap_element_section_refs(&mut module, &remap).expect("remap must succeed");
+
+        let rebuilt = module.element_section_bytes.as_ref().unwrap();
+        let reader =
+            wasmparser::ElementSectionReader::new(wasmparser::BinaryReader::new(rebuilt, 0))
+                .expect("rebuilt payload must parse");
+        assert_eq!(reader.count(), 1);
+        let mut got = Vec::new();
+        for elem in reader {
+            if let wasmparser::ElementItems::Functions(funcs) = elem.unwrap().items {
+                got.extend(funcs.into_iter().map(|f| f.unwrap()));
+            }
+        }
+        // Each original slot's func index mapped through old→new, IN ORDER.
+        assert_eq!(
+            got,
+            vec![3, 2, 6, 8],
+            "#196: element table slots must map each funcref in place, preserving order"
+        );
+    }
+
+    /// #196: the fail-safe guard must detect a function-referencing element
+    /// table (so callers skip optimization), and must NOT trip on a module
+    /// with no element section or an empty one.
+    #[test]
+    fn test_element_section_references_functions_detection() {
+        // Function-referencing active segment → guard trips.
+        let mut m = empty_module();
+        m.element_section_bytes = Some(vec![
+            0x01, 0x00, 0x41, 0x00, 0x0b, 0x02, 0x00, 0x01, // 1 seg, 2 funcs [0,1]
+        ]);
+        assert!(
+            element_section_references_functions(&m),
+            "must detect a function-referencing element table"
+        );
+
+        // No element section → safe to optimize.
+        let mut m2 = empty_module();
+        m2.element_section_bytes = None;
+        assert!(!element_section_references_functions(&m2));
+
+        // Empty element section (zero segments) → no table, safe to optimize.
+        let mut m3 = empty_module();
+        m3.element_section_bytes = Some(vec![0x00]); // segment count = 0
+        assert!(!element_section_references_functions(&m3));
     }
 }

--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -6887,6 +6887,17 @@ pub mod optimize {
         // For backwards compatibility, this function applies the core optimizations
         // The full optimization pipeline is in loom-cli/src/main.rs lines 237-246
 
+        // #196 (CRITICAL): a module with a function-referencing element segment
+        // (indirect-call table) cannot currently be optimized with behavioral
+        // certainty — loom's structural verification can't detect a scrambled or
+        // stale function-pointer table (v1.1.11 silent-miscompiled falcon's
+        // flight controller). Skip optimization entirely and leave the module
+        // unchanged, mirroring the component path's fail-safe. Correctness over
+        // optimization; re-enable behind a behavioral-differential gate (#196).
+        if super::fused_optimizer::element_section_references_functions(module) {
+            return Ok(());
+        }
+
         // Phase 0: Fused component optimizations (adapter devirtualization, type/import
         // dedup, dead function elimination). These are safe no-ops on non-fused modules.
         // Best-effort and non-fatal, but the outcome is always reported — on success


### PR DESCRIPTION
## CRITICAL — gale #196: flight-control silent miscompile

v1.1.11's #172 encoding fix made falcon's core module 0 *encode* validly, which **unmasked a worse pre-existing defect**: loom's optimization of a module with a function-referencing element segment produces **valid-but-wrong** code. The fused pass changes function indices across several sub-passes but only remaps the `call_indirect` table in one; the parse→re-encode round-trip corrupts further. Output passes `wasm-tools validate` **and** loom `--verify` (both structural) yet flies wrong — falcon SIL `run-position-hold` **0.13 m → 593.8 m**. v1.1.10 was *accidentally* safe (invalid → fallback); v1.1.11 removed the accident.

## Fix (correctness — prime directive)
Behavioral verification is the only thing that catches this, and loom has none. So per "skip rather than risk incorrect": **skip optimization of any core module with a function-referencing element segment**, keeping original bytes — in both `optimize_core_module` (component) and `optimize_module` (standalone). Restores v1.1.10's safe behavior deliberately. #172's segment-count fix is retained (real, just insufficient).

## Validation (behavioral, not just structural)
`falcon-flight-v1.34.wasm` optimized output now matches the original bit-for-bit under wasmtime: `run-stabilization` 0.023399856, `run-position-hold` 0.1317415 (was 0.329 / 593.79); validates. New tests: detection + per-slot remap identity. **395 lib + 85 integration pass.**

## Limitation / next
Indirect-call-table modules are now unoptimized (safe). Re-enabling is gated on a **behavioral differential** in loom CI (run exports before/after, compare) — structural `--verify` is insufficient, as #196 proved.

## Known-red (pre-existing)
- Rocq Formal Proofs (upstream; #169).

Closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)