### PR TITLE
fix(build): migrate to cranelift-isle 0.132.1 + wasmparser 0.251 — tag builds again (closes #198, v1.1.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to LOOM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.13] - 2026-06-11
+
+**Build fix: the tag builds from a clean checkout again (#198).** v1.1.12's
+committed dependency set (`cranelift-isle 0.132.1`, `wasmparser 0.251`, pulled
+by the wasmtime-45 bump) had landed without the corresponding source migration,
+so `cargo install` from the tag failed. Migrated the code to the new APIs.
+
+### Fixed
+
+- **cranelift-isle 0.132.1:** `loom-shared/build.rs` `CodegenOptions` literal now
+  uses `..Default::default()` (it grew fields); removed the duplicate `(type u32
+  …)` from `types.isle` (the prelude now provides it); added `extern crate
+  alloc` so the generated code's `alloc::` paths resolve.
+- **wasmparser 0.251:** migrated import parsing to the new `Imports` enum
+  (`Single(usize, Import)`; the compact-import encodings `Compact1`/`Compact2`
+  are *not* modeled — loom refuses to parse such a module rather than mis-record
+  its import table, falling back to original bytes); `ComponentExternName` is now
+  a struct (`.name`, was tuple `.0`); dropped the removed `cm_async_builtins`
+  feature flag.
+
+### Validation
+
+- Builds clean against the committed deps (isle codegen + workspace). 395 lib +
+  85 integration tests pass. Behavioral falcon gate unchanged from v1.1.12 —
+  `run-stabilization` 0.023399856, `run-position-hold` 0.1317415 (matches the
+  original; the #196 fail-safe and the import-parse migration are both correct).
+
+### Note
+
+A committed `Cargo.lock` (or pinned deps) would prevent the from-tag
+non-reproducibility this exposed; tracked separately.
+
 ## [1.1.12] - 2026-06-10
 
 **CRITICAL bug fix: stop silently miscompiling modules with indirect-call

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.12"
+version = "1.1.13"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/loom-core/src/component_executor.rs
+++ b/loom-core/src/component_executor.rs
@@ -135,7 +135,9 @@ impl ComponentExecutor {
                     for export in reader {
                         let export = export.context("Failed to read component export")?;
                         canonical_functions.push(CanonicalFunctionInfo {
-                            name: export.name.0.to_string(),
+                            // wasmparser 0.251: ComponentExternName is a struct
+                            // with a `name` field (was a tuple `.0`) (#198).
+                            name: export.name.name.to_string(),
                             param_count: 0,
                             return_count: 1,
                             preserved: true,
@@ -144,9 +146,15 @@ impl ComponentExecutor {
                 }
                 Payload::ImportSection(reader) => {
                     for import in reader {
-                        let import = import.context("Failed to read import")?;
+                        // wasmparser 0.251 `Imports` enum (#198): only the
+                        // classic `Single` import carries a name here; the
+                        // compact encodings are skipped in this diagnostic view.
+                        let name = match import.context("Failed to read import")? {
+                            wasmparser::Imports::Single(_, import) => import.name,
+                            _ => continue,
+                        };
                         canonical_functions.push(CanonicalFunctionInfo {
-                            name: format!("import_{}", import.name),
+                            name: format!("import_{name}"),
                             param_count: 0,
                             return_count: 0,
                             preserved: true,

--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -872,7 +872,8 @@ pub mod parse {
         let mut inflated = WasmFeatures::default().inflate();
         inflated.cm_async = true;
         inflated.cm_async_stackful = true;
-        inflated.cm_async_builtins = true;
+        // `cm_async_builtins` was removed in wasmparser 0.251 (folded into the
+        // cm_async feature set); the two flags above cover it (#198).
         WasmFeatures::from_inflated(inflated)
     }
 
@@ -922,7 +923,21 @@ pub mod parse {
                 Payload::ImportSection(reader) => {
                     // Capture imports (functions, globals, memories, tables)
                     for import in reader.clone() {
-                        let import = import?;
+                        // wasmparser 0.251 yields `Imports` (an enum) per entry:
+                        // `Single` is the classic (module, name, ty) import;
+                        // `Compact1`/`Compact2` are the new compact-imports
+                        // encoding. loom does not model compact imports, so it
+                        // refuses to parse such a module rather than mis-record
+                        // its import table — the caller then keeps the original
+                        // bytes (fail-safe, #198).
+                        let import = match import? {
+                            wasmparser::Imports::Single(_, import) => import,
+                            _ => {
+                                return Err(anyhow!(
+                                    "compact import encoding (wasmparser 0.251) not supported"
+                                ));
+                            }
+                        };
                         let kind = match import.ty {
                             wasmparser::TypeRef::Func(type_idx) => ImportKind::Func(type_idx),
                             wasmparser::TypeRef::Memory(mem_type) => ImportKind::Memory(Memory {

--- a/loom-shared/build.rs
+++ b/loom-shared/build.rs
@@ -44,9 +44,14 @@ fn main() {
         }
     }
 
-    // Configure code generation options
+    // Configure code generation options.
+    // `..Default::default()` keeps this forward-compatible as cranelift-isle's
+    // CodegenOptions grows fields across versions (#198: 0.132.1 added
+    // emit_logging / match_arm_split_threshold / prefixes / … — an exhaustive
+    // literal broke the build from-tag).
     let options = isle::codegen::CodegenOptions {
         exclude_global_allow_pragmas: true,
+        ..Default::default()
     };
 
     // Compile ISLE files to Rust code

--- a/loom-shared/isle/types.isle
+++ b/loom-shared/isle/types.isle
@@ -143,5 +143,6 @@
 ;; This allows recursive structures without infinite size
 (type Value (primitive Value))
 
-;; Primitive types for local variable indices
-(type u32 (primitive u32))
+;; `u32` is provided by the cranelift-isle prelude (since 0.132.1). We must NOT
+;; redefine it here or ISLE errors with "Type with name 'u32' defined more than
+;; once" (#198). Uses of `u32` below resolve to the prelude type.

--- a/loom-shared/src/lib.rs
+++ b/loom-shared/src/lib.rs
@@ -7,6 +7,10 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 
+// cranelift-isle 0.132.1's generated code emits `alloc::` paths; bring the
+// alloc crate into scope so the included ISLE output resolves them (#198).
+extern crate alloc;
+
 /// WebAssembly value types
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ValueType {


### PR DESCRIPTION
## gale #198 — v1.1.12 doesn't build from tag

v1.1.12's committed deps (`cranelift-isle 0.132.1`, `wasmparser 0.251`, pulled by the wasmtime-45 bump) landed **without** the source migration, so `cargo install` from the tag failed. (Earlier builds only passed on a stale Cargo.lock — the non-reproducibility gale flagged.)

## Migrated
**cranelift-isle 0.132.1:** `CodegenOptions` literal → `..Default::default()`; dropped duplicate `(type u32 …)` (prelude provides it); `extern crate alloc` for generated `alloc::` paths.
**wasmparser 0.251:** import parsing → new `Imports` enum (`Single(usize, Import)`; compact encodings `Compact1`/`Compact2` are **not** modeled → `parse_wasm` errs → caller keeps original bytes, fail-safe); `ComponentExternName.0` → `.name`; dropped removed `cm_async_builtins`.

## Validation
Builds clean against committed deps. **395 lib + 85 integration** pass. **Behavioral falcon gate unchanged** — `run-stabilization` 0.023399856, `run-position-hold` 0.1317415 (matches original; import-parse migration + #196 fail-safe both behaviorally correct).

## Note
A committed `Cargo.lock`/pinned deps would prevent this from-tag non-reproducibility class; tracked separately.

## Known-red (pre-existing)
- Rocq Formal Proofs (upstream; #169).

Closes #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)