### PR TITLE
fix(testing): un-red main — adapt to floated wasmtime 45 + criterion black_box

### DIFF
--- a/loom-core/benches/optimization_benchmarks.rs
+++ b/loom-core/benches/optimization_benchmarks.rs
@@ -2,8 +2,9 @@
 //!
 //! Run with: cargo bench
 
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use loom_core::{optimize, parse};
+use std::hint::black_box;
 
 /// Benchmark constant folding performance
 fn bench_constant_folding(c: &mut Criterion) {

--- a/loom-testing/benches/corpus_baseline.rs
+++ b/loom-testing/benches/corpus_baseline.rs
@@ -888,7 +888,7 @@ fn corpus_baseline(c: &mut Criterion) {
                     let row = measure_fixture(env, name, path, note);
                     guard[idx] = Some(row);
                 }
-                criterion::black_box(idx)
+                std::hint::black_box(idx)
             });
         });
     }

--- a/loom-testing/src/differential.rs
+++ b/loom-testing/src/differential.rs
@@ -325,9 +325,9 @@ impl DifferentialExecutor {
 
         // Load modules
         let original_module = Module::new(&self.engine, original_bytes)
-            .context("Failed to compile original module")?;
+            .map_err(|e| anyhow::anyhow!("Failed to compile original module: {e}"))?;
         let optimized_module = Module::new(&self.engine, optimized_bytes)
-            .context("Failed to compile optimized module")?;
+            .map_err(|e| anyhow::anyhow!("Failed to compile optimized module: {e}"))?;
 
         // Try to instantiate
         let (original_instance, optimized_instance) = match (

--- a/loom-testing/src/emi/mod.rs
+++ b/loom-testing/src/emi/mod.rs
@@ -373,9 +373,11 @@ fn collect_function_outputs(
     engine: &Engine,
     wasm_bytes: &[u8],
 ) -> Result<std::collections::HashMap<String, Vec<Val>>> {
-    let module = Module::new(engine, wasm_bytes).context("Failed to compile module")?;
+    let module = Module::new(engine, wasm_bytes)
+        .map_err(|e| anyhow::anyhow!("Failed to compile module: {e}"))?;
     let mut store = Store::new(engine, ());
-    let instance = Instance::new(&mut store, &module, &[]).context("Failed to instantiate")?;
+    let instance = Instance::new(&mut store, &module, &[])
+        .map_err(|e| anyhow::anyhow!("Failed to instantiate: {e}"))?;
 
     let mut outputs = std::collections::HashMap::new();
 

--- a/loom-testing/src/lib.rs
+++ b/loom-testing/src/lib.rs
@@ -229,10 +229,10 @@ impl TestResult {
         linker.func_wrap("wasi_snapshot_preview1", "proc_exit", |_: i32| {})?;
 
         // Try to load modules
-        let original_module =
-            Module::new(&engine, original).context("Failed to load original module")?;
-        let optimized_module =
-            Module::new(&engine, optimized).context("Failed to load optimized module")?;
+        let original_module = Module::new(&engine, original)
+            .map_err(|e| anyhow::anyhow!("Failed to load original module: {e}"))?;
+        let optimized_module = Module::new(&engine, optimized)
+            .map_err(|e| anyhow::anyhow!("Failed to load optimized module: {e}"))?;
 
         // Try to instantiate (may fail due to missing imports)
         let original_instance = match linker.instantiate(&mut store, &original_module) {
@@ -360,7 +360,7 @@ impl TestResult {
                     ValType::F64 => Val::F64(0),
                     _ => return FunctionCompareResult::Skipped,
                 };
-                opt_results[i] = orig_results[i].clone();
+                opt_results[i] = orig_results[i];
             }
 
             // Call original
@@ -491,10 +491,10 @@ impl TestResult {
         let engine = Engine::default();
 
         // Load both modules
-        let loom_module =
-            Module::new(&engine, loom_wasm).context("Failed to load LOOM optimized module")?;
+        let loom_module = Module::new(&engine, loom_wasm)
+            .map_err(|e| anyhow::anyhow!("Failed to load LOOM optimized module: {e}"))?;
         let wasm_opt_module = Module::new(&engine, wasm_opt_wasm)
-            .context("Failed to load wasm-opt optimized module")?;
+            .map_err(|e| anyhow::anyhow!("Failed to load wasm-opt optimized module: {e}"))?;
 
         // Try to instantiate and compare exports
         let loom_results = Self::extract_function_results(&engine, &loom_module);


### PR DESCRIPTION
## Why main is red (and it's not any code change)

`main` (commit 6f07be4) is failing CI across **Build, Test, Clippy, Z3 Verification, Code Coverage**. Root cause: **two floated dependencies** — CI doesn't pin because `Cargo.lock` is gitignored.

### 1. wasmtime → 45.0.1
`wasmtime::Error` is its own `Box<dyn Error>`-like type that does **not** implement `std::error::Error`, so anyhow's `.context()` extension trait no longer resolves on wasmtime `Result`s → `error[E0599]`.

- 45.0.0 and 45.0.1 are **byte-identical** in the error module, so pinning wouldn't help — the code must adapt. The break surfaced via feature-unification drift from the cranelift `0.132.0 → 0.132.1` bump.
- **Fix:** replace the wasmtime `.context("msg")` sites with `.map_err(|e| anyhow!("msg: {e}"))`, which depends only on `Display` (always provided by `wasmtime::Error`) and is immune to this error-type churn.
  - `differential.rs`: `Module::new` ×2
  - `lib.rs`: `Module::new` ×4
  - `emi/mod.rs`: `Module::new`, `Instance::new`

### 2. criterion deprecated `black_box`
The Clippy job runs `--all-targets -D warnings`, so `-D deprecated` fails on `criterion::black_box` in the benches. **Fix:** migrate to `std::hint::black_box`.
- `loom-core/benches/optimization_benchmarks.rs` (import + 10 sites)
- `loom-testing/benches/corpus_baseline.rs` (1 site)

Also cleared a latent clippy `clone_on_copy` (`lib.rs:363`) — `wasmtime::Val` is `Copy` in 45. Both layers were **masked**: compilation stops at the first errors, so each only surfaced once the prior layer was fixed.

## Verification

```
cargo clippy --all-targets --all-features -- -D warnings   # passes
cargo check -p loom-testing --features runtime             # passes
cargo tree -p loom-testing --features runtime -i wasmtime  # wasmtime v45.0.1
```
Confirmed compiling against the exact broken version (45.0.1).

## Durable follow-up

This is the concrete failure mode behind **#142**: floating dependencies break `main` with zero code changes. Committing `Cargo.lock` (and building `--locked` in CI) is the durable fix and is tracked there.

Refs #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)