### PR TITLE
chore(release): v1.1.14 — restore release binaries + build-health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,8 +283,13 @@ jobs:
       # wasip2 component model cannot resolve with wasi-sdk-25.
       # Last known working: 1.93.1 (2026-02-11), confirmed in CI run 22541892477.
       # TODO: Unpin when Rust stable + wasi-sdk resolves the wasip2 thread init issue.
-      - uses: dtolnay/rust-toolchain@1.93.1
+      # NB: pin the *toolchain* via the input, not the action ref. `@<X.Y.Z>`
+      # pins the action's git tag, not Rust; that old action revision derives
+      # "stable" from the calendar, which now overshoots to a not-yet-released
+      # 1.100.0 and fails. `@stable` + explicit toolchain installs exactly 1.93.1.
+      - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: "1.93.1"
           targets: wasm32-wasip2
       - uses: Swatinem/rust-cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ two build breaks that floated in via unpinned dependencies.
   (`E0599`); `criterion` deprecated `black_box`. Migrated the `loom-testing`
   wasmtime call sites to `.map_err(|e| anyhow!(...))` and the benches to
   `std::hint::black_box`.
+- **WASM Build CI job pinned to a real toolchain.** `dtolnay/rust-toolchain@1.93.1`
+  pins the *action* git tag, not Rust; that old action revision derives "stable"
+  from the calendar, which had drifted to a not-yet-released `1.100.0` and broke
+  the job on `main`. Switched to `@stable` + explicit `toolchain: "1.93.1"`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to LOOM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.14] - 2026-06-14
+
+**Release-engineering + build-health release.** No optimizer behavior change —
+the falcon behavioral gate is unchanged from v1.1.13. This release restores
+release-binary uploads (the headline fix for downstream consumers) and repairs
+two build breaks that floated in via unpinned dependencies.
+
+### Fixed
+
+- **Release binaries ship again (#142, #216).** The old `release.yml` `release`
+  job had `needs: [build-native, build-wasm]`; the `wasm32-wasip2` build failed
+  to link (`pthread`/`__wasi_init_tp`, from the unconditional `rayon` dep),
+  which **skipped the entire release job** — so every release v0.6.0..v1.1.13
+  uploaded only the compliance tarball, never the `loom` binary. The release job
+  now `needs: [build-binaries]` only (a 4-target native matrix with
+  `fail-fast: false`), decoupling the binaries from the fragile wasm/OCI publish.
+  Verified by re-running the new workflow against the v1.1.13 tag, which
+  retroactively shipped the full asset set.
+- **`main` un-redded after floated-dependency breaks (#202).** `wasmtime` floated
+  to 45.0.1, whose `Error` no longer satisfies anyhow's `.context()` bound
+  (`E0599`); `criterion` deprecated `black_box`. Migrated the `loom-testing`
+  wasmtime call sites to `.map_err(|e| anyhow!(...))` and the benches to
+  `std::hint::black_box`.
+
+### Changed
+
+- **Unified release-artifact standard (#216).** Each release now publishes per-OS
+  archives `loom-vX.Y.Z-<triple>.{tar.gz,zip}`, a CycloneDX SBOM
+  `loom-X.Y.Z.cdx.json`, `SHA256SUMS.txt` with a keyless cosign signature
+  (`.sig`/`.pem`/`.cosign.bundle`), a SLSA build-provenance attestation, and
+  `build-env.txt` — matching the pulseengine/synth reference.
+- **Removed the vestigial Sphinx scaffold (#201).** It never built (no
+  `conf.py`/`source/`) and its requirements-traceability role is owned by rivet;
+  the `docs/` Markdown renders directly on GitHub.
+
+### Note
+
+A committed `Cargo.lock` (build `--locked` in CI) would prevent the floated-dep
+breaks that #202 fixed; still tracked separately.
+
 ## [1.1.13] - 2026-06-11
 
 **Build fix: the tag builds from a clean checkout again (#198).** v1.1.12's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.13"
+version = "1.1.14"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump + CHANGELOG for **v1.1.14**. No optimizer behavior change — the falcon behavioral gate is unchanged from v1.1.13. Content already on main since v1.1.13:

- **#142 / #216** — release-binary uploads restored + unified artifact standard. The release job was gated on the fragile `wasm32-wasip2` build (`needs: [build-native, build-wasm]`), which skipped all binary uploads when that build failed. Now `create-release needs: [build-binaries]` only. Verified live by retroactively shipping v1.1.13's full asset set via `workflow_dispatch`.
- **#202** — un-redded `main` after floated-dependency breaks (wasmtime 45 `.context`/`E0599`, criterion `black_box` deprecation).
- **#201** — removed the vestigial Sphinx scaffold (superseded by rivet).

After merge: tag `v1.1.14` → the release workflow ships the per-OS binaries + SBOM + signed checksums automatically (the normal tag-push path), giving downstream `rules_wasm_component` a fresh release to pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)