### PR TITLE
chore(release): v1.1.14 — dead-stores fix + release binaries + build health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,8 +283,14 @@ jobs:
       # wasip2 component model cannot resolve with wasi-sdk-25.
       # Last known working: 1.93.1 (2026-02-11), confirmed in CI run 22541892477.
       # TODO: Unpin when Rust stable + wasi-sdk resolves the wasip2 thread init issue.
-      - uses: dtolnay/rust-toolchain@1.100.0
+      # NB: pin the *toolchain* via the input, not the action ref. `@<X.Y.Z>`
+      # pins the action's git tag, not Rust; that revision derives "stable" from
+      # the calendar. Dependabot #206 bumped this to `@1.100.0`, a Rust that does
+      # not exist yet, breaking the job on main. `@stable` + explicit toolchain
+      # installs exactly 1.93.1. Do NOT let dependabot bump the ref again.
+      - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: "1.93.1"
           targets: wasm32-wasip2
       - uses: Swatinem/rust-cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to LOOM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.14] - 2026-06-15
+
+Correctness + release-engineering release. One optimizer correctness fix (#220);
+the rest is release/build-health. The falcon behavioral gate is restored to its
+reference value by #220.
+
+### Fixed
+
+- **Dead-store elimination no longer miscompiles float-memory functions (#220,
+  #221).** The `dead-stores` pass dropped a LIVE float store in the meld-fused
+  falcon core — valid-but-wrong, `run-stabilization` 0.023399856 → 0.32916. The
+  Z3 translation validator silently skips functions with float load/store
+  (`Ok(true)` without a proof), so the pass's liveness analysis shipped an
+  unsound elimination with no safety net. Fix: a `contains_unverifiable_float_
+  memory` guard makes the pass skip any function the verifier cannot prove —
+  never eliminate under uncertainty (the #196 stance). Restores 0.023399856.
+- **Release binaries ship again (#142, #216).** The release job was gated on the
+  fragile `wasm32-wasip2` build; any wasm link failure skipped all binary
+  uploads. Decoupled: `create-release` now `needs: [build-binaries]` only (4
+  native targets, `fail-fast: false`). Verified by retroactively shipping
+  v1.1.13's full asset set.
+- **`main` un-redded after floated-dependency breaks (#202).** `wasmtime` 45.0.1
+  dropped anyhow's `.context()` bound (`E0599`); `criterion` deprecated
+  `black_box`. Migrated the call sites.
+- **WASM Build CI pinned to a real toolchain.** Dependabot (#206) bumped
+  `dtolnay/rust-toolchain` to `@1.100.0` — which pins the *action* tag, not Rust,
+  and that revision derives a not-yet-released Rust 1.100.0, breaking the job.
+  Switched to `@stable` + explicit `toolchain: "1.93.1"`.
+
+### Changed
+
+- **Unified release-artifact standard (#216).** Per release: per-OS archives, a
+  CycloneDX SBOM, `SHA256SUMS.txt` with a keyless cosign signature, a SLSA
+  build-provenance attestation, and `build-env.txt` (matches pulseengine/synth).
+- **Removed the vestigial Sphinx scaffold (#201).** It never built; rivet owns
+  requirements traceability and the `docs/` Markdown renders on GitHub.
+
+### Note
+
+A committed `Cargo.lock` (CI `--locked`) would prevent the floated-dep breaks
+(#202, #206); still tracked separately.
+
 ## [1.1.13] - 2026-06-11
 
 **Build fix: the tag builds from a clean checkout again (#198).** v1.1.12's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.13"
+version = "1.1.14"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
**v1.1.14 release** off current main (supersedes the stale #218; consolidates the release bump with the WASM Build CI toolchain fix so main goes fully green).

Everything since v1.1.13:
- **#220/#221** — dead-stores no longer miscompiles float-memory functions (restores the falcon `run-stabilization` 0.023399856). *(critical correctness)*
- **#142/#216** — release-binary uploads restored + unified artifact standard (verified live on v1.1.13).
- **#202** — un-redded main after wasmtime-45 + criterion floated-dep breaks.
- **#201** — removed vestigial Sphinx scaffold.
- **CI** — pin the WASM Build toolchain (`@stable` + `toolchain: "1.93.1"`), reverting dependabot #206's bump to the non-existent Rust `@1.100.0` that broke the job on main.

After merge: tag `v1.1.14` → release.yml ships per-OS binaries + SBOM + signed checksums on the tag path, with the #220 correctness fix included.

This run should be fully green now that the WASM Build toolchain is pinned (only the Rocq + Verification-Gate advisory fails remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)