### PR TITLE
feat(238): behavioral differential gate — self-certify non-Z3-backstoppable transforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,61 @@ jobs:
             echo "Z3 WASM verification: $verified verified, $skipped skipped"
           fi
 
+  differential-gate:
+    name: Behavioral Differential Gate (#238)
+    # ubuntu-latest: default features pull `verification` (needs z3); the
+    # `differential` feature additionally pulls wasmtime. Both build here.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Z3
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y z3
+      - name: Build loom with the differential gate
+        run: cargo build --release -p loom-cli --features differential
+      - name: Differentially gate the runnable core-module corpus
+        run: |
+          # Policy (#238): the CLI `--differential` gate HARD-FAILS on BOTH
+          # divergence and inconclusive (it refuses to certify behavior it never
+          # observed). For this fixed corpus the CI job is a narrower consumer:
+          #   - DIVERGENCE / invalid output -> CI FAILURE (a real miscompile)
+          #   - inconclusive (no runnable export / exec coverage gap)
+          #                                 -> logged SKIP, not a CI failure
+          # Component fixtures are excluded: component-model execution is not
+          # wired yet, so they are always inconclusive (gap tracked in #238/#239).
+          set -u
+          corpus=(tests/corpus/*.wasm loom-core/tests/fixtures/repro-219/sem.loom.wasm)
+          certified=0; skipped=0; diverged=()
+          for w in "${corpus[@]}"; do
+            [ -f "$w" ] || continue
+            name=$(basename "$w")
+            if log=$(./target/release/loom optimize "$w" -o /tmp/diff_out.wasm --differential 2>&1); then
+              echo "✅ certified: $name"
+              certified=$((certified + 1))
+            elif echo "$log" | grep -q "inconclusive"; then
+              echo "⏭️  inconclusive (skipped, not runnable): $name"
+              skipped=$((skipped + 1))
+            else
+              echo "❌ DIVERGENCE / invalid: $name"
+              echo "$log" | tail -3
+              diverged+=("$name")
+            fi
+          done
+          echo ""
+          echo "Differential gate: $certified certified, $skipped inconclusive-skipped, ${#diverged[@]} diverged"
+          if [ "${#diverged[@]}" -gt 0 ]; then
+            echo "❌ behavioral divergence on: ${diverged[*]}"
+            exit 1
+          fi
+          if [ "$certified" -eq 0 ]; then
+            echo "❌ gate certified 0 modules — corpus or executor regression"
+            exit 1
+          fi
+          echo "✅ differential gate green ($certified certified)"
+
   wasm-build:
     name: WASM Build (wasm32-wasip2 with Z3)
     # Stays on ubuntu-latest: installs wasi-sdk into /opt with sudo mkdir/tar.

--- a/loom-cli/Cargo.toml
+++ b/loom-cli/Cargo.toml
@@ -23,6 +23,9 @@ anyhow = { workspace = true }
 wsc-attestation = { version = "0.9", optional = true }
 serde_json = { version = "1.0", optional = true }
 
+# Behavioral differential gate (#238, optional — pulls wasmtime; off by default)
+loom-testing = { path = "../loom-testing", optional = true }
+
 [features]
 # Default features - verification and attestation enabled for production safety
 default = ["verification", "attestation"]
@@ -30,6 +33,10 @@ default = ["verification", "attestation"]
 verification = ["loom-core/verification"]
 # Enable transformation attestation support
 attestation = ["wsc-attestation", "serde_json"]
+# Enable `loom optimize --differential` behavioral gate (#238). Off by default
+# because it pulls wasmtime; build with `--features differential` to gate on
+# observed execution equivalence (loom-testing's `runtime` is a default feature).
+differential = ["loom-testing"]
 
 [[bin]]
 name = "loom"

--- a/loom-cli/src/main.rs
+++ b/loom-cli/src/main.rs
@@ -63,6 +63,16 @@ enum Commands {
         /// Maximum is 4 (the size of the default fleet).
         #[arg(long, default_value_t = 1)]
         islands: usize,
+
+        /// Behavioral differential gate (#238): after optimizing, execute the
+        /// original and optimized modules through wasmtime and compare outputs.
+        /// HARD FAIL — on any output divergence OR if execution was inconclusive
+        /// (could not instantiate / no runnable exports), the optimization is
+        /// REJECTED: the original is written to the output path and the process
+        /// exits non-zero. Refuses to certify behavior it never observed.
+        #[arg(long)]
+        #[cfg(feature = "differential")]
+        differential: bool,
     },
 
     /// Verify ISLE optimization rules
@@ -263,6 +273,49 @@ fn count_instructions_from_bytes(bytes: &[u8]) -> usize {
         .unwrap_or(0)
 }
 
+/// Behavioral differential gate (#238). When enabled (`original` is `Some`),
+/// execute the original and optimized WASM through wasmtime and compare outputs.
+/// HARD FAIL: on any divergence or inconclusive execution, write the ORIGINAL
+/// (safe, unoptimized) bytes to `output_path` and return `Err` so the process
+/// exits non-zero. A no-op when the gate is disabled (`original` is `None`).
+#[allow(unused_variables)]
+fn maybe_differential_gate(
+    original: Option<&[u8]>,
+    optimized_wasm: &[u8],
+    output_path: &str,
+) -> Result<()> {
+    let original = match original {
+        Some(o) => o,
+        None => return Ok(()),
+    };
+    #[cfg(feature = "differential")]
+    {
+        use loom_testing::differential::{DifferentialExecutor, ExecutionConfig};
+        println!("🔬 Differential gate: executing original vs optimized...");
+        // Use the `thorough` profile so the gate actually exercises wider exports
+        // (up to 6 params) instead of skipping them — fewer false "inconclusive"
+        // rejections on real modules. Strict certification still requires zero
+        // skipped functions; this just widens what we can drive.
+        let exec = DifferentialExecutor::with_config(ExecutionConfig::thorough())
+            .context("Failed to initialize differential executor")?;
+        let result = exec
+            .test_pair(original, optimized_wasm)
+            .context("Differential execution failed")?;
+        println!("   {}", result.summary());
+        if let Some(reason) = result.strict_failure_reason() {
+            fs::write(output_path, original)
+                .context("Failed to write original after differential rejection")?;
+            println!("✗ Differential gate REJECTED — wrote ORIGINAL to {output_path}");
+            return Err(anyhow!("differential gate rejected optimization: {reason}"));
+        }
+        println!(
+            "✓ Differential gate: behavior preserved on {} executed export(s)",
+            result.functions_tested
+        );
+    }
+    Ok(())
+}
+
 /// Optimize command implementation
 #[allow(clippy::too_many_arguments)]
 fn optimize_command(
@@ -274,6 +327,7 @@ fn optimize_command(
     add_attestation: bool,
     passes: Option<Vec<String>>,
     islands: usize,
+    run_differential: bool,
 ) -> Result<()> {
     println!("🔧 LOOM Optimizer v{}", env!("CARGO_PKG_VERSION"));
     println!("Input: {}", input);
@@ -372,6 +426,20 @@ fn optimize_command(
         None
     };
 
+    // Capture the UNOPTIMIZED wasm for the behavioral differential gate (#238).
+    // For wasm input that's the input bytes; for WAT we re-encode the freshly
+    // parsed (pre-optimization) module so original and optimized are both wasm.
+    let original_wasm: Option<Vec<u8>> = if run_differential {
+        Some(if is_wat_input {
+            loom_core::encode::encode_wasm(&module)
+                .context("Failed to encode original (from WAT) for differential gate")?
+        } else {
+            input_bytes.clone()
+        })
+    } else {
+        None
+    };
+
     // Collect statistics before optimization
     let mut stats = OptimizationStats {
         instructions_before: count_instructions(&module),
@@ -438,6 +506,15 @@ fn optimize_command(
                 "output.wasm".to_string()
             }
         });
+        if run_differential {
+            let opt_wasm = if output_wat {
+                loom_core::encode::encode_wasm(&module)
+                    .context("Failed to encode optimized module for differential gate")?
+            } else {
+                output_bytes.clone()
+            };
+            maybe_differential_gate(original_wasm.as_deref(), &opt_wasm, &output_path)?;
+        }
         fs::write(&output_path, &output_bytes).context("Failed to write output file")?;
         println!("✓ Written to: {}", output_path);
 
@@ -739,6 +816,17 @@ fn optimize_command(
             "output.wasm".to_string()
         }
     });
+    // Behavioral differential gate (#238): on HARD FAIL this writes the original
+    // to output_path and returns Err (non-zero exit) before the optimized write.
+    if run_differential {
+        let opt_wasm = if output_wat {
+            loom_core::encode::encode_wasm(&module)
+                .context("Failed to encode optimized module for differential gate")?
+        } else {
+            output_bytes.clone()
+        };
+        maybe_differential_gate(original_wasm.as_deref(), &opt_wasm, &output_path)?;
+    }
     fs::write(&output_path, &output_bytes).context("Failed to write output file")?;
     println!("✓ Written to: {}", output_path);
 
@@ -869,11 +957,17 @@ fn main() -> Result<()> {
             attestation,
             passes,
             islands,
+            #[cfg(feature = "differential")]
+            differential,
         }) => {
             #[cfg(feature = "attestation")]
             let add_attestation = attestation;
             #[cfg(not(feature = "attestation"))]
             let add_attestation = false;
+            #[cfg(feature = "differential")]
+            let run_differential = differential;
+            #[cfg(not(feature = "differential"))]
+            let run_differential = false;
             optimize_command(
                 input,
                 output,
@@ -883,6 +977,7 @@ fn main() -> Result<()> {
                 add_attestation,
                 passes,
                 islands,
+                run_differential,
             )?;
         }
 
@@ -957,7 +1052,8 @@ mod tests {
             false,
             false, // attestation
             None,
-            1, // islands: serial path
+            1,     // islands: serial path
+            false, // run_differential
         );
 
         assert!(result.is_ok(), "Optimization should succeed");
@@ -994,7 +1090,8 @@ mod tests {
             false,
             false, // attestation
             None,
-            1, // islands: serial path
+            1,     // islands: serial path
+            false, // run_differential
         );
 
         assert!(result.is_ok(), "Optimization with stats should succeed");
@@ -1028,7 +1125,8 @@ mod tests {
             true,  // Enable verification
             false, // attestation
             None,
-            1, // islands: serial path
+            1,     // islands: serial path
+            false, // run_differential
         );
 
         assert!(
@@ -1065,7 +1163,8 @@ mod tests {
             false,
             false, // attestation (disabled for WAT)
             None,
-            1, // islands: serial path
+            1,     // islands: serial path
+            false, // run_differential
         );
 
         assert!(

--- a/loom-testing/src/differential.rs
+++ b/loom-testing/src/differential.rs
@@ -236,9 +236,56 @@ impl DifferentialTestResult {
         )
     }
 
-    /// Check if the test passed (semantics preserved and output valid)
+    /// Check if the test passed (semantics preserved and output valid).
+    ///
+    /// Lenient: a module that could not be instantiated or had no testable
+    /// exports still "passes" (nothing was observed to diverge). Suitable for a
+    /// best-effort tool, NOT for a certifying gate — use [`Self::passed_strict`].
     pub fn passed(&self) -> bool {
         self.semantics_preserved && self.optimized_valid
+    }
+
+    /// Strict gate verdict (#238): certify ONLY when the differential actually
+    /// executed and observed agreement on every tested export.
+    ///
+    /// HARD FAIL on "inconclusive": if nothing could be executed
+    /// (`functions_tested == 0`) or any export was skipped, this returns
+    /// `false`. The gate refuses to certify behavior it never observed — it does
+    /// not assume "couldn't test ⇒ preserved". This is the certifier semantics
+    /// for `loom optimize --differential`; lenient `passed()` is for the tool.
+    pub fn passed_strict(&self) -> bool {
+        self.optimized_valid
+            && self.semantics_preserved
+            && self.functions_diverged == 0
+            && self.functions_skipped == 0
+            && self.functions_tested > 0
+    }
+
+    /// Human-readable reason this result is not strictly certifiable, or `None`
+    /// if [`Self::passed_strict`] holds. Used by the gate to explain a rejection.
+    pub fn strict_failure_reason(&self) -> Option<String> {
+        if self.passed_strict() {
+            return None;
+        }
+        if !self.optimized_valid {
+            return Some("optimized module is not valid WebAssembly".to_string());
+        }
+        if !self.semantics_preserved || self.functions_diverged > 0 {
+            return Some(format!(
+                "{} function(s) diverged between original and optimized",
+                self.functions_diverged.max(1)
+            ));
+        }
+        if self.functions_tested == 0 {
+            return Some(
+                "inconclusive: no exported function could be executed (missing host imports / no runnable exports) — gate refuses to certify unobserved behavior"
+                    .to_string(),
+            );
+        }
+        Some(format!(
+            "inconclusive: {} function(s) skipped (untestable signature/imports) — gate refuses to certify unobserved behavior",
+            self.functions_skipped
+        ))
     }
 }
 
@@ -270,17 +317,28 @@ impl DifferentialExecutor {
     /// 3. Validates the output is valid WebAssembly
     /// 4. Compares execution on all exported functions
     pub fn test_optimization(&self, wasm_bytes: &[u8]) -> Result<DifferentialTestResult> {
-        let original_size = wasm_bytes.len();
-
-        // Validate input
-        wasmparser::validate(wasm_bytes).context("Input is not valid WebAssembly")?;
-
-        // Optimize with LOOM
         let optimized_bytes = self.optimize_with_loom(wasm_bytes)?;
+        self.test_pair(wasm_bytes, &optimized_bytes)
+    }
+
+    /// Differentially test an ALREADY-PRODUCED `(original, optimized)` pair
+    /// (#238). Unlike [`Self::test_optimization`], this does NOT re-optimize —
+    /// it compares the exact bytes the caller emitted, so it can gate the real
+    /// output of `loom optimize`. Validates the optimized module, then compares
+    /// execution of every exported function via wasmtime.
+    pub fn test_pair(
+        &self,
+        original_bytes: &[u8],
+        optimized_bytes: &[u8],
+    ) -> Result<DifferentialTestResult> {
+        let original_size = original_bytes.len();
         let optimized_size = optimized_bytes.len();
 
+        // Validate input
+        wasmparser::validate(original_bytes).context("Original is not valid WebAssembly")?;
+
         // Validate output
-        let optimized_valid = wasmparser::validate(&optimized_bytes).is_ok();
+        let optimized_valid = wasmparser::validate(optimized_bytes).is_ok();
         if !optimized_valid {
             return Ok(DifferentialTestResult {
                 semantics_preserved: false,
@@ -297,7 +355,12 @@ impl DifferentialExecutor {
         }
 
         // Compare execution
-        self.compare_execution(wasm_bytes, &optimized_bytes, original_size, optimized_size)
+        self.compare_execution(
+            original_bytes,
+            optimized_bytes,
+            original_size,
+            optimized_size,
+        )
     }
 
     /// Optimize WebAssembly bytes using LOOM library directly
@@ -321,13 +384,26 @@ impl DifferentialExecutor {
         let mut optimized_store = Store::new(&self.engine, ());
 
         // Create linker with common imports
-        let linker = self.create_linker()?;
+        let mut linker = self.create_linker()?;
 
         // Load modules
         let original_module = Module::new(&self.engine, original_bytes)
             .map_err(|e| anyhow::anyhow!("Failed to compile original module: {e}"))?;
         let optimized_module = Module::new(&self.engine, optimized_bytes)
             .map_err(|e| anyhow::anyhow!("Failed to compile optimized module: {e}"))?;
+
+        // #238 host-import stubbing: define every still-unresolved import as a
+        // trap, so modules with arbitrary host imports (WASI variants, env, custom)
+        // can be instantiated rather than hard-failing as inconclusive. Optimization
+        // never ADDS imports, so the original's import set ⊇ the optimized's — one
+        // pass over the original covers both. A function that actually calls such an
+        // import traps IDENTICALLY in original and optimized (same name → same trap
+        // string), so `ExecutionResult::Trap` compares equal ⇒ still a match, not a
+        // divergence. The explicit stubs in `create_linker` (which return real
+        // values) take precedence for the names they cover.
+        linker
+            .define_unknown_imports_as_traps(&original_module)
+            .map_err(|e| anyhow::anyhow!("Failed to stub unknown imports: {e}"))?;
 
         // Try to instantiate
         let (original_instance, optimized_instance) = match (
@@ -661,7 +737,20 @@ impl DifferentialExecutor {
                     .collect();
                 ExecutionResult::Success(result_strs)
             }
-            Err(e) => ExecutionResult::Trap(e.to_string()),
+            Err(e) => {
+                // Normalize traps to their offset-INDEPENDENT code. A WebAssembly
+                // trap is semantically "this input traps with reason R"; the code
+                // offset in the backtrace (e.g. `0x289`) is not observable program
+                // behavior and optimization legitimately shifts it. Comparing the
+                // full backtrace string would flag two identical-outcome traps as a
+                // divergence (false positive on every optimized module, #238). So
+                // compare the trap CODE: both-trap-same-reason ⇒ equivalent; one
+                // trapping while the other returns a value ⇒ a real divergence.
+                match e.downcast_ref::<wasmtime::Trap>() {
+                    Some(trap) => ExecutionResult::Trap(format!("trap:{trap:?}")),
+                    None => ExecutionResult::Trap("error:non-trap".to_string()),
+                }
+            }
         }
     }
 }
@@ -877,6 +966,137 @@ impl ValidationResult {
 #[cfg(all(test, feature = "runtime"))]
 mod tests {
     use super::*;
+
+    /// Build a result with the given execution accounting (other fields fixed).
+    fn result(
+        tested: usize,
+        matched: usize,
+        diverged: usize,
+        skipped: usize,
+    ) -> DifferentialTestResult {
+        DifferentialTestResult {
+            semantics_preserved: diverged == 0,
+            original_size: 100,
+            optimized_size: 80,
+            optimized_valid: true,
+            functions_tested: tested,
+            functions_matched: matched,
+            functions_diverged: diverged,
+            functions_skipped: skipped,
+            function_results: vec![],
+            issues: vec![],
+        }
+    }
+
+    #[test]
+    fn strict_gate_certifies_only_observed_agreement() {
+        // Clean: every tested export matched, none skipped/diverged → certify.
+        let clean = result(3, 3, 0, 0);
+        assert!(clean.passed_strict(), "clean run must certify");
+        assert!(clean.strict_failure_reason().is_none());
+
+        // Divergence → reject (and lenient passed() also false here).
+        let diverged = result(3, 2, 1, 0);
+        assert!(!diverged.passed_strict());
+        assert!(!diverged.passed());
+        assert!(
+            diverged
+                .strict_failure_reason()
+                .unwrap()
+                .contains("diverged")
+        );
+    }
+
+    #[test]
+    fn strict_gate_hard_fails_on_inconclusive() {
+        // Could not instantiate / no runnable exports: tested == 0.
+        // Lenient passed() is TRUE (nothing observed to break) but the gate
+        // must HARD FAIL — it never observed the behavior (#238).
+        let uninstantiable = DifferentialTestResult {
+            semantics_preserved: true, // matches compare_execution's lenient default
+            functions_tested: 0,
+            functions_skipped: 1,
+            ..result(0, 0, 0, 1)
+        };
+        assert!(uninstantiable.passed(), "lenient tool view");
+        assert!(
+            !uninstantiable.passed_strict(),
+            "gate must refuse to certify unobserved behavior"
+        );
+        assert!(
+            uninstantiable
+                .strict_failure_reason()
+                .unwrap()
+                .contains("no exported function could be executed")
+        );
+
+        // Some exports ran, but others were skipped → still inconclusive → reject.
+        let partial = result(2, 2, 0, 1);
+        assert!(!partial.passed_strict());
+        assert!(partial.strict_failure_reason().unwrap().contains("skipped"));
+    }
+
+    #[test]
+    fn corpus_module_behavior_is_preserved_and_harness_is_sound() {
+        // Regression guard (#238) on a real corpus module:
+        //  1. SELF: identical bytes MUST NOT diverge — guards against an unsound
+        //     harness (e.g. trap-backtrace offsets leaking into the comparison,
+        //     which previously produced false divergences).
+        //  2. OPT: loom's optimization MUST NOT change observed behavior.
+        // Uses the `thorough` profile so wide exports (state_machine's 5-param
+        // `pack`) are actually exercised, not skipped.
+        let path = "../tests/corpus/state_machine.wasm";
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(_) => return, // corpus not present in this checkout — skip
+        };
+        let exec = DifferentialExecutor::with_config(ExecutionConfig::thorough()).unwrap();
+
+        let self_r = exec.test_pair(&bytes, &bytes).unwrap();
+        assert_eq!(
+            self_r.functions_diverged, 0,
+            "identical bytes diverged — differential HARNESS is unsound (not loom)"
+        );
+
+        let opt_r = exec.test_optimization(&bytes).unwrap();
+        assert!(opt_r.functions_tested > 0, "no exports were executed");
+        assert_eq!(
+            opt_r.functions_diverged, 0,
+            "loom optimization changed observed behavior on a real corpus module"
+        );
+        assert!(
+            opt_r.passed_strict(),
+            "corpus module should certify under the gate: {:?}",
+            opt_r.strict_failure_reason()
+        );
+    }
+
+    #[test]
+    fn unknown_imports_are_stubbed_so_module_runs() {
+        // A module importing an unknown host fn but whose tested export is pure:
+        // with trap-stubbing (#238 (b)) it instantiates and the export executes,
+        // so the gate can actually certify it instead of hard-failing inconclusive.
+        let wat = r#"
+            (module
+              (import "host" "mystery" (func $m (param i32) (result i32)))
+              (func (export "pure") (param i32) (result i32)
+                local.get 0 i32.const 3 i32.mul))
+        "#;
+        let wasm = wat::parse_str(wat).expect("wat");
+        let exec = DifferentialExecutor::new().expect("exec");
+        // Identical bytes ⇒ must certify; the point is instantiation now succeeds.
+        let r = exec.test_pair(&wasm, &wasm).expect("test_pair");
+        assert!(
+            r.functions_tested >= 1,
+            "pure export should execute despite the unknown import; tested={}",
+            r.functions_tested
+        );
+        assert!(
+            r.passed_strict(),
+            "module with a stubbed unknown import must certify: {:?}",
+            r.strict_failure_reason()
+        );
+    }
 
     #[test]
     fn test_simple_function_equivalence() {


### PR DESCRIPTION
Closes #238. v1.1.17 candidate.

## What
`loom optimize --differential` (opt-in `differential` cargo feature; pulls wasmtime, off by default): after optimizing, execute original vs optimized through wasmtime and compare outputs. **HARD FAIL** — on any divergence OR inconclusive execution, write the **original** and exit non-zero. The gate refuses to certify behavior it never observed.

This makes #219 and future instruction-level transforms **self-certifying** instead of silicon-gated (the #219 void-seam carrier-forward is not Z3-backstoppable; until now its only gate was gale's G474RE board).

## Pieces
- **loom-testing**: `test_pair(orig,opt)` (compares already-produced bytes, no re-optimize); `passed_strict()`/`strict_failure_reason()`; unknown host imports auto-stubbed as traps so real modules instantiate; **traps compared by offset-independent code, not backtrace string** (the offset shifts under optimization — was a false-divergence on every module); `thorough` profile so wide exports are exercised.
- **loom-cli**: `--differential` wired on serial + islands write paths.
- **CI**: `differential-gate` job over the runnable core-module corpus (divergence → red, inconclusive → logged skip, certified==0 → red).

## Evidence
Corpus — httparse, json_lite, state_machine, and gale's own `sem.loom.wasm` — all certify: **certified=4, inconclusive=0, diverged=0**. Executed evidence that loom preserves behavior on real modules.

Local: loom-testing 21 lib tests, loom-cli 8 tests, clippy clean, fmt clean.

## Known gaps (follow-ups, not blockers)
- Component-model execution not wired → components are inconclusive under the gate (tracked with #239).
- Refs #240 (the algebraic mid-end / proof-carrying-facts work this gate unblocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)