### PR TITLE
fix(deps): pin cranelift-isle to 0.132 — 0.133 MSRV (rustc 1.94) breaks wasm build + main CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,12 @@ wasmprinter = "0.252"
 wat = "1.241"
 wit-component = "0.252"
 
-# ISLE compiler and runtime
-cranelift-isle = "0.133"
+# ISLE compiler and runtime.
+# Pinned to 0.132: cranelift-isle 0.133.x raised its MSRV to rustc 1.94.0, which
+# is not yet stable (stable is 1.93.1), breaking the wasm32-wasip2 build and
+# main CI (#236 bump). 0.132.x is the known-good line v1.1.13–v1.1.16 shipped on.
+# Revisit once rustc 1.94 is stable (or when the lockfile is committed, #142).
+cranelift-isle = "0.132"
 
 # CLI
 clap = { version = "4.5", features = ["derive", "cargo"] }


### PR DESCRIPTION
## Problem
`cranelift-isle 0.133.x` raised its MSRV to **rustc 1.94.0**, which is not yet stable (stable is 1.93.1). The `WASM Build (wasm32-wasip2 with Z3)` job runs `cargo +1.93.1 build -p loom-cli` and fails at dependency resolution:

```
error: rustc 1.93.1 is not supported by the following packages:
  cranelift-isle@0.133.1 requires rustc 1.94.0
```

Introduced by the #236 bump to `0.133`. This reddens **main CI** and every PR based on it (e.g. #241) with no code change — the floating-deps failure mode.

## Fix
Pin the direct workspace dependency back to `cranelift-isle = "0.132"` — the known-good line v1.1.13–v1.1.16 shipped on. loom uses cranelift-isle directly (loom-shared/loom-isle for ISLE codegen).

**Verified:** `cargo +1.93.0 check -p loom-cli` compiles `cranelift-isle 0.132.3` with no MSRV error. The transitive `0.133.1` (via wasmtime 46 in loom-testing) is *not* in loom-cli's build graph, so the wasm build — which builds only `-p loom-cli` — is unaffected.

## Durable follow-up
This will recur every time dependabot bumps a dep past current-stable MSRV. The durable fix is committing a `Cargo.lock` (#142), and/or a dependabot ignore rule for cranelift-isle until rustc 1.94 is stable.

Refs #236, #142. Unblocks #241 (behavioral differential gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)