### PR TITLE
chore: rivet traceability hygiene — validate clean under 0.22.0

### DIFF
--- a/safety/requirements/safety-case.yaml
+++ b/safety/requirements/safety-case.yaml
@@ -12,7 +12,7 @@ artifacts:
         For every WebAssembly module M that LOOM accepts for optimization,
         the output module M' is semantically equivalent to M — identical
         observable behavior for all valid inputs.
-      goal-type: top-level
+      goal-type: system-level
     links:
       - type: goal-addresses-hazard
         target: H-1
@@ -45,7 +45,7 @@ artifacts:
       claim: >
         Every output module passes wasm-tools validate and maintains
         correct stack discipline, section ordering, and LEB128 encoding.
-      goal-type: top-level
+      goal-type: system-level
     links:
       - type: goal-addresses-hazard
         target: H-4
@@ -61,7 +61,7 @@ artifacts:
         The Z3 SMT encoding and Rocq proof models accurately represent
         WebAssembly operational semantics, ensuring verification results
         are trustworthy.
-      goal-type: top-level
+      goal-type: system-level
     links:
       - type: goal-addresses-hazard
         target: H-12
@@ -75,7 +75,7 @@ artifacts:
         Identical inputs produce identical outputs across runs, platforms,
         and compiler versions. No HashMap iteration order or floating-point
         host arithmetic introduces non-determinism.
-      goal-type: top-level
+      goal-type: system-level
     links:
       - type: goal-addresses-hazard
         target: H-18
@@ -93,7 +93,7 @@ artifacts:
         Optimization of meld-fused component modules preserves all
         component external interfaces, adapter semantics, and Meld/Kiln
         ABI compatibility.
-      goal-type: top-level
+      goal-type: system-level
     links:
       - type: goal-addresses-hazard
         target: H-13
@@ -106,7 +106,7 @@ artifacts:
       claim: >
         Functions containing unsupported instructions or control flow
         patterns beyond the verified boundary are passed through unchanged.
-      goal-type: top-level
+      goal-type: system-level
     links:
       - type: goal-addresses-hazard
         target: H-11
@@ -182,7 +182,7 @@ artifacts:
     title: Self-optimization test (dogfooding)
     status: approved
     fields:
-      evidence-type: test
+      evidence-type: test-report
     description: >
       LOOM optimizes its own WebAssembly binary. The optimized LOOM
       must produce valid WASM and (when behavioral equivalence is
@@ -196,7 +196,7 @@ artifacts:
     title: Differential testing vs wasm-opt
     status: approved
     fields:
-      evidence-type: test
+      evidence-type: test-report
     description: >
       Every CI run compares LOOM output against Binaryen wasm-opt -O3.
       Both must produce valid WASM. Size and validity are compared.
@@ -209,7 +209,7 @@ artifacts:
     title: wasm-tools validate on all CI fixtures
     status: approved
     fields:
-      evidence-type: test
+      evidence-type: test-report
     description: >
       Every optimized fixture is validated with wasm-tools validate in
       CI. Any invalid output fails the build.
@@ -329,7 +329,7 @@ artifacts:
     title: Per-pass revert counter + --stats surfacing
     status: approved
     fields:
-      evidence-type: test
+      evidence-type: test-report
       description: >
         Every optimization pass that runs the Z3 translation validator
         wraps the transform in verify_or_revert. On rejection, the
@@ -347,7 +347,7 @@ artifacts:
     title: Byte-identical output regression test on canonical fixtures
     status: approved
     fields:
-      evidence-type: test
+      evidence-type: test-report
       description: >
         TEST-DETERMINISTIC-OUTPUT in verification.yaml asserts that
         running `loom optimize` twice on a fixed input produces
@@ -363,7 +363,7 @@ artifacts:
     title: Component-Model pass-through validation post-optimization
     status: approved
     fields:
-      evidence-type: test
+      evidence-type: test-report
       description: >
         The component_optimizer.rs pipeline runs wasm-tools validate
         (component variant) on the optimized component before emitting

--- a/safety/requirements/verification.yaml
+++ b/safety/requirements/verification.yaml
@@ -3,8 +3,9 @@
 # Each `TEST-*` artifact is `type: feature` with `fields.method: automated-test`
 # and a list of `fields.steps[].run` shell commands that the
 # `tools/run_verification.py` harness executes during the Verification Gate
-# CI job. The link `type: satisfies, target: REQ-N` is what closes the
-# rivet lifecycle-coverage check for that requirement.
+# CI job. The link `type: verifies, target: REQ-N` is what closes the
+# rivet lifecycle-coverage check for that requirement (every requirement
+# must have an incoming `verifies` backlink from at least one test).
 #
 # Pattern is borrowed verbatim from pulseengine/spar commit ba329f3d.
 #
@@ -32,13 +33,13 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release --lib -p loom-core -- verify::
+            cargo test --release --lib -p loom-core -- verify::
     status: passing
     tags: [v100, verification, z3]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-1
-      - type: satisfies
+      - type: verifies
         target: REQ-6
 
   - id: TEST-IPA-FUNCTION-SUMMARIES
@@ -53,13 +54,13 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release --lib -p loom-core -- summary::
+            cargo test --release --lib -p loom-core -- summary::
     status: passing
     tags: [v100, ipa, verification]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-1
-      - type: satisfies
+      - type: verifies
         target: REQ-4
 
   # ============================================================================
@@ -81,17 +82,24 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release --lib -p loom-core -- test_cse_does_not_dedupe
+            cargo test --release --lib -p loom-core -- test_cse_does_not_dedupe
     status: passing
     tags: [v100, cse, safety]
     links:
+      - type: verifies
+        target: REQ-2
+      # REQ-2 (No temporary fixes) has no design-decision/feature that
+      # *satisfies* it other than this CI enforcement mechanism: the
+      # negative CSE guards are what make "fix it properly or don't ship
+      # it" observable in the build. Keep the `satisfies` backlink so the
+      # requirement stays covered by both a satisfier and a verifier.
       - type: satisfies
         target: REQ-2
-      - type: satisfies
+      - type: verifies
         target: REQ-3
-      - type: satisfies
+      - type: verifies
         target: REQ-4
-      - type: satisfies
+      - type: verifies
         target: REQ-5
 
   - id: TEST-CSE-CROSS-CALL-DEDUP
@@ -106,13 +114,13 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release --lib -p loom-core -- test_cse_dedupes
+            cargo test --release --lib -p loom-core -- test_cse_dedupes
     status: passing
     tags: [v100, cse, ipa]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-1
-      - type: satisfies
+      - type: verifies
         target: REQ-3
 
   # ============================================================================
@@ -131,11 +139,11 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && bazel build //proofs/... 2>&1 || echo "SKIP if bazel not available on this runner"
+            bazel build //proofs/... 2>&1 || echo "SKIP if bazel not available on this runner"
     status: passing
     tags: [v100, rocq, proofs]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-7
 
   # ============================================================================
@@ -153,11 +161,11 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release -p loom-testing -- self_optimization 2>&1 || echo "SKIP if dogfood target missing"
+            cargo test --release -p loom-testing -- self_optimization 2>&1 || echo "SKIP if dogfood target missing"
     status: passing
     tags: [v100, dogfooding]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-8
 
   # ============================================================================
@@ -176,11 +184,11 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release --lib -p loom-core -- spec_features
+            cargo test --release --lib -p loom-core -- spec_features
     status: passing
     tags: [v100, wasm-spec]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-9
 
   # ============================================================================
@@ -200,11 +208,11 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo build --release -p loom-cli && ./target/release/loom optimize scripts/mythos/gale_measure/gale_in_baseline.wasm --attestation false -o /tmp/loom-pipeline-smoke.wasm
+            cargo build --release -p loom-cli && ./target/release/loom optimize scripts/mythos/gale_measure/gale_in_baseline.wasm --attestation false -o /tmp/loom-pipeline-smoke.wasm
     status: passing
     tags: [v100, cli, pipeline]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-10
 
   # ============================================================================
@@ -224,11 +232,11 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release --lib -p loom-core -- specialize_adapters
+            cargo test --release --lib -p loom-core -- specialize_adapters
     status: passing
     tags: [v100, component-model]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-11
 
   # ============================================================================
@@ -247,13 +255,13 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release --lib -p loom-core -- encode wasmparser
+            cargo test --release --lib -p loom-core -- encode wasmparser
     status: passing
     tags: [v100, validation]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-12
-      - type: satisfies
+      - type: verifies
         target: REQ-13
 
   # ============================================================================
@@ -273,11 +281,11 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release --lib -p loom-core -- stack
+            cargo test --release --lib -p loom-core -- stack
     status: passing
     tags: [v100, stack-validation]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-13
 
   # ============================================================================
@@ -296,11 +304,11 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release --lib -p loom-core -- test_null_check
+            cargo test --release --lib -p loom-core -- test_null_check
     status: passing
     tags: [v100, determinism]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-14
 
   # ============================================================================
@@ -320,11 +328,11 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo build --release -p loom-cli && PER_RUN_TIMEOUT=60 bash scripts/measure_corpus.sh
+            cargo build --release -p loom-cli && PER_RUN_TIMEOUT=60 bash scripts/measure_corpus.sh
     status: passing
     tags: [v100, measurement]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-15
 
   # ============================================================================
@@ -343,11 +351,11 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && (test -d fuzz && cd fuzz && cargo check) || echo "SKIP if fuzz directory absent"
+            (test -d fuzz && cd fuzz && cargo check) || echo "SKIP if fuzz directory absent"
     status: passing
     tags: [v100, fuzzing]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-16
 
   # ============================================================================
@@ -366,11 +374,11 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h LIBRARY_PATH=/opt/homebrew/lib cargo test --release -p loom-testing 2>&1 || echo "SKIP if differential dependencies absent"
+            cargo test --release -p loom-testing 2>&1 || echo "SKIP if differential dependencies absent"
     status: passing
     tags: [v100, abi, meld-interop]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-17
 
   # ============================================================================
@@ -388,9 +396,9 @@ artifacts:
       method: automated-test
       steps:
         - run: |
-            cd /Users/r/git/pulseengine/loom && (rustup target list --installed | grep -q wasm32-wasip2 && cargo build --release --target wasm32-wasip2 -p loom-core) || echo "SKIP if wasm32-wasip2 toolchain absent"
+            (rustup target list --installed | grep -q wasm32-wasip2 && cargo build --release --target wasm32-wasip2 -p loom-core) || echo "SKIP if wasm32-wasip2 toolchain absent"
     status: passing
     tags: [v100, build-target]
     links:
-      - type: satisfies
+      - type: verifies
         target: REQ-18

--- a/safety/requirements/verification.yaml
+++ b/safety/requirements/verification.yaml
@@ -34,7 +34,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release --lib -p loom-core -- verify::
-    status: passing
+    status: verified
     tags: [v100, verification, z3]
     links:
       - type: verifies
@@ -55,7 +55,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release --lib -p loom-core -- summary::
-    status: passing
+    status: verified
     tags: [v100, ipa, verification]
     links:
       - type: verifies
@@ -83,7 +83,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release --lib -p loom-core -- test_cse_does_not_dedupe
-    status: passing
+    status: verified
     tags: [v100, cse, safety]
     links:
       - type: verifies
@@ -115,7 +115,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release --lib -p loom-core -- test_cse_dedupes
-    status: passing
+    status: verified
     tags: [v100, cse, ipa]
     links:
       - type: verifies
@@ -140,7 +140,7 @@ artifacts:
       steps:
         - run: |
             bazel build //proofs/... 2>&1 || echo "SKIP if bazel not available on this runner"
-    status: passing
+    status: verified
     tags: [v100, rocq, proofs]
     links:
       - type: verifies
@@ -162,7 +162,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release -p loom-testing -- self_optimization 2>&1 || echo "SKIP if dogfood target missing"
-    status: passing
+    status: verified
     tags: [v100, dogfooding]
     links:
       - type: verifies
@@ -185,7 +185,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release --lib -p loom-core -- spec_features
-    status: passing
+    status: verified
     tags: [v100, wasm-spec]
     links:
       - type: verifies
@@ -209,7 +209,7 @@ artifacts:
       steps:
         - run: |
             cargo build --release -p loom-cli && ./target/release/loom optimize scripts/mythos/gale_measure/gale_in_baseline.wasm --attestation false -o /tmp/loom-pipeline-smoke.wasm
-    status: passing
+    status: verified
     tags: [v100, cli, pipeline]
     links:
       - type: verifies
@@ -233,7 +233,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release --lib -p loom-core -- specialize_adapters
-    status: passing
+    status: verified
     tags: [v100, component-model]
     links:
       - type: verifies
@@ -256,7 +256,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release --lib -p loom-core -- encode wasmparser
-    status: passing
+    status: verified
     tags: [v100, validation]
     links:
       - type: verifies
@@ -282,7 +282,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release --lib -p loom-core -- stack
-    status: passing
+    status: verified
     tags: [v100, stack-validation]
     links:
       - type: verifies
@@ -305,7 +305,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release --lib -p loom-core -- test_null_check
-    status: passing
+    status: verified
     tags: [v100, determinism]
     links:
       - type: verifies
@@ -329,7 +329,7 @@ artifacts:
       steps:
         - run: |
             cargo build --release -p loom-cli && PER_RUN_TIMEOUT=60 bash scripts/measure_corpus.sh
-    status: passing
+    status: verified
     tags: [v100, measurement]
     links:
       - type: verifies
@@ -352,7 +352,7 @@ artifacts:
       steps:
         - run: |
             (test -d fuzz && cd fuzz && cargo check) || echo "SKIP if fuzz directory absent"
-    status: passing
+    status: verified
     tags: [v100, fuzzing]
     links:
       - type: verifies
@@ -375,7 +375,7 @@ artifacts:
       steps:
         - run: |
             cargo test --release -p loom-testing 2>&1 || echo "SKIP if differential dependencies absent"
-    status: passing
+    status: verified
     tags: [v100, abi, meld-interop]
     links:
       - type: verifies
@@ -397,7 +397,7 @@ artifacts:
       steps:
         - run: |
             (rustup target list --installed | grep -q wasm32-wasip2 && cargo build --release --target wasm32-wasip2 -p loom-core) || echo "SKIP if wasm32-wasip2 toolchain absent"
-    status: passing
+    status: verified
     tags: [v100, build-target]
     links:
       - type: verifies

--- a/safety/stpa/control-structure.yaml
+++ b/safety/stpa/control-structure.yaml
@@ -28,6 +28,9 @@ controllers:
       - Input is a valid WebAssembly binary
       - All Operator variants have corresponding Instruction mappings
       - Unsupported operators are tracked for function-level skip decisions
+    links:
+      - type: acts-on
+        target: CP-1
 
   - id: CTRL-2
     name: ISLE term rewriter
@@ -57,6 +60,9 @@ controllers:
       - Terms faithfully represent instruction semantics
       - Rewrite rules preserve equivalence
       - Term environment tracks local variable bindings
+    links:
+      - type: acts-on
+        target: CP-2
 
   - id: CTRL-3
     name: Optimization pipeline orchestrator
@@ -100,6 +106,9 @@ controllers:
       - Functions with unsupported instructions must be skipped entirely
       - Phase ordering is fixed and deterministic
       - Each phase receives output of previous phase
+    links:
+      - type: acts-on
+        target: CP-1
 
   - id: CTRL-4
     name: Stack validator
@@ -160,6 +169,9 @@ controllers:
       - IR types map to valid WASM section encodings
       - Function body byte lengths are computed correctly
       - All indices (type, function, memory, table) are valid
+    links:
+      - type: acts-on
+        target: CP-3
 
   - id: CTRL-7
     name: Component model optimizer
@@ -182,6 +194,9 @@ controllers:
       - Component external interface must be preserved
       - Adapter collapse only valid for same-memory, no-transform cases
       - Fused modules retain Meld/Kiln ABI compatibility
+    links:
+      - type: acts-on
+        target: CP-1
 
 controlled-processes:
   - id: CP-1
@@ -190,13 +205,9 @@ controlled-processes:
       The in-memory Module struct containing types, functions, tables,
       memories, globals, and exports. All optimization phases read and
       modify this structure.
-    links:
-      - type: acted-on-by
-        target: CTRL-1
-      - type: acted-on-by
-        target: CTRL-3
-      - type: acted-on-by
-        target: CTRL-7
+    # Acted on by CTRL-1 (parser), CTRL-3 (pipeline orchestrator),
+    # CTRL-7 (component optimizer) — see the `acts-on` links on those
+    # controllers, which rivet resolves into `acted-on-by` backlinks here.
 
   - id: CP-2
     name: ISLE term environment
@@ -204,9 +215,7 @@ controlled-processes:
       The term environment used during ISLE rewriting. Contains Value
       terms representing instruction sequences, local variable bindings,
       and the simplification context.
-    links:
-      - type: acted-on-by
-        target: CTRL-2
+    # Acted on by CTRL-2 (ISLE term rewriter) — see its `acts-on` link.
 
   - id: CP-3
     name: Output WASM binary
@@ -214,6 +223,4 @@ controlled-processes:
       The final encoded WebAssembly binary. Once encoded, this is the
       artifact consumed by downstream tools (Meld, Kiln, Synth, or
       direct execution runtimes).
-    links:
-      - type: acted-on-by
-        target: CTRL-6
+    # Acted on by CTRL-6 (binary encoder) — see its `acts-on` link.

--- a/safety/stpa/hazards.yaml
+++ b/safety/stpa/hazards.yaml
@@ -178,7 +178,7 @@ hazards:
       compositional-analysis false positives. CODE-VERIFIED: active on
       main branch.
     losses: [L-2]
-    status: MITIGATED
+    status: accepted
     mitigation: |
       Re-enabled by 84ce9f7 ("fix(safety): re-enable post-optimization
       stack validation"). Active in lib.rs:6782+ Phase 5 block.
@@ -193,7 +193,7 @@ hazards:
       ['verification', 'attestation']"). Main CI test job now exercises
       Z3-backed verification on the default feature set.
     losses: [L-3]
-    status: MITIGATED
+    status: accepted
     mitigation: |
       Wave 2 (#77) added Z3-based ISLE rule verification (REQ-6, SG-3).
       verification feature is default-on in loom-core and loom-cli Cargo.toml.
@@ -208,7 +208,7 @@ hazards:
       BrIf/BrTable now receive structural ISLE rewrites (constant folding,
       algebraic identities, strength reduction) without dataflow tracking.
     losses: [L-4]
-    status: MITIGATED
+    status: accepted
     mitigation: |
       PR #53 (ac01a19) and PR #80 (c1eb8f3) together cover the prior skip
       cases. Functions with control flow now optimize via rewrite_pure().
@@ -222,7 +222,7 @@ hazards:
       local_info, global_constants. Pure-lookup HashMaps remain where
       iteration order does not affect output.
     losses: [L-5]
-    status: MITIGATED
+    status: accepted
     mitigation: |
       Wave 2 (REQ-14, #77) swapped 5 iteration-order-sensitive HashMaps
       to BTreeMap. Verified by running optimizer twice on same input.


### PR DESCRIPTION
Makes `rivet validate` PASS on loom (was **23 errors / 63 warnings** on main → **0 errors / 33 warnings**). No code touched — `safety/**` only.

## Fixes
- **CP-1/2/3 undeclared `acted-on-by` link** → moved to the correct forward `acts-on` direction on the acting controllers; rivet derives the backlink. Same graph, schema-valid.
- **SG-1..6 `goal-type: top-level`** (invalid) → `system-level`.
- **SOL-3..8 `evidence-type: test`** (invalid) → `test-report` (SOL-1 analysis / SOL-2 formal-proof left as-is).
- **REQ-1..18 had no `verifies` backlink** → the existing TEST-* artifacts linked with `satisfies`; switched the 23 REQ-targeted links to `verifies` (each grounded in a real cargo test / Z3 `verify::` / Rocq proof / dogfood / fuzz target — no fabricated coverage).
- **rivet 0.22.0 status-enum drift** → 16x TEST-* `passing`→`verified`, 4x hazard `MITIGATED`→`accepted`.
- **Stripped absolute local paths** (`/Users`, `/opt/homebrew`) from `verification.yaml` `run:` commands → repo-relative + env-driven.

## Review note
The 4 hazard `MITIGATED`→`accepted` remaps are a safety-posture wording choice (the 0.22.0 enum has no `mitigated`). Flag if you'd prefer `verified` or a schema extension instead.

Residual 33 warnings are coverage nudges / unknown-field INFO (e.g. `feature.method`), non-failing — a separate follow-up if we want them zero.