### PR TITLE
fix(ci): migrate loom-testing to rand 0.10 API — unblocks all CI

### DIFF
--- a/loom-testing/src/emi/mod.rs
+++ b/loom-testing/src/emi/mod.rs
@@ -121,9 +121,9 @@ pub fn emi_test(wasm_bytes: &[u8], config: EmiConfig) -> Result<EmiTestResult> {
     let engine = Engine::default();
 
     // Set up RNG
-    let mut rng: Box<dyn RngCore> = match config.seed {
+    let mut rng: Box<dyn Rng> = match config.seed {
         Some(seed) => Box::new(rand::rngs::StdRng::seed_from_u64(seed)),
-        None => Box::new(rand::thread_rng()),
+        None => Box::new(rand::rng()),
     };
 
     // 1. Analyze for dead code regions
@@ -147,10 +147,10 @@ pub fn emi_test(wasm_bytes: &[u8], config: EmiConfig) -> Result<EmiTestResult> {
 
     for i in 0..config.iterations {
         // Pick random dead region and mutation strategy
-        let region_idx = rng.gen_range(0..dead_regions.len());
+        let region_idx = rng.random_range(0..dead_regions.len());
         let region = &dead_regions[region_idx];
 
-        let strategy_idx = rng.gen_range(0..config.strategies.len());
+        let strategy_idx = rng.random_range(0..config.strategies.len());
         let strategy = config.strategies[strategy_idx];
 
         // Apply mutation to create variant
@@ -272,9 +272,9 @@ pub fn emi_test(wasm_bytes: &[u8], config: EmiConfig) -> Result<EmiTestResult> {
 #[cfg(not(feature = "runtime"))]
 pub fn emi_test(wasm_bytes: &[u8], config: EmiConfig) -> Result<EmiTestResult> {
     // Set up RNG
-    let mut rng: Box<dyn RngCore> = match config.seed {
+    let mut rng: Box<dyn Rng> = match config.seed {
         Some(seed) => Box::new(rand::rngs::StdRng::seed_from_u64(seed)),
-        None => Box::new(rand::thread_rng()),
+        None => Box::new(rand::rng()),
     };
 
     // 1. Analyze for dead code regions
@@ -295,10 +295,10 @@ pub fn emi_test(wasm_bytes: &[u8], config: EmiConfig) -> Result<EmiTestResult> {
 
     for i in 0..config.iterations {
         // Pick random dead region and mutation strategy
-        let region_idx = rng.gen_range(0..dead_regions.len());
+        let region_idx = rng.random_range(0..dead_regions.len());
         let region = &dead_regions[region_idx];
 
-        let strategy_idx = rng.gen_range(0..config.strategies.len());
+        let strategy_idx = rng.random_range(0..config.strategies.len());
         let strategy = config.strategies[strategy_idx];
 
         // Apply mutation to create variant

--- a/loom-testing/tests/stress_test.rs
+++ b/loom-testing/tests/stress_test.rs
@@ -14,7 +14,7 @@
 //! ```
 
 use loom_testing::emi::{EmiConfig, MutationStrategy, analyze_dead_code, emi_test};
-use rand::Rng;
+use rand::prelude::*;
 use std::time::Instant;
 
 /// Default iteration count for the per-fixture EMI stress test.
@@ -401,8 +401,6 @@ fn test_generated_wasm_fuzzing() {
     println!("║     Generated WASM Fuzzing (100 random modules)                  ║");
     println!("╚══════════════════════════════════════════════════════════════════╝\n");
 
-    use rand::prelude::*;
-
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
     let mut passed = 0;
     let mut failed = 0;
@@ -443,12 +441,12 @@ fn test_generated_wasm_fuzzing() {
 
 /// Generate a random but syntactically valid WAT module
 fn generate_random_wat<R: Rng>(rng: &mut R, _seed: usize) -> String {
-    let num_funcs = rng.gen_range(1..=3);
+    let num_funcs = rng.random_range(1..=3);
     let mut funcs = String::new();
 
     for f in 0..num_funcs {
-        let num_locals = rng.gen_range(0..=3);
-        let num_instrs = rng.gen_range(1..=10);
+        let num_locals = rng.random_range(0..=3);
+        let num_instrs = rng.random_range(1..=10);
 
         let mut locals = String::new();
         for l in 0..num_locals {
@@ -502,10 +500,10 @@ fn generate_random_instr<R: Rng>(rng: &mut R, num_locals: usize) -> String {
     ];
 
     // Add local operations if we have locals
-    if num_locals > 0 && rng.gen_bool(0.3) {
-        let local_idx = rng.gen_range(0..num_locals);
+    if num_locals > 0 && rng.random_bool(0.3) {
+        let local_idx = rng.random_range(0..num_locals);
         return format!("    i32.const 0\n    local.set $l{}\n", local_idx);
     }
 
-    choices[rng.gen_range(0..choices.len())].to_string()
+    choices[rng.random_range(0..choices.len())].to_string()
 }


### PR DESCRIPTION
**Unblocks all loom CI** (currently fully red). `loom-testing` failed to compile: `cannot find trait RngCore` / `cannot find function thread_rng in crate rand`.

Root cause: Dependabot #265 bumped `loom-testing/Cargo.toml` to `rand = "0.10"` but never updated the source, so the spec and code were out of sync (and with Cargo.lock gitignored, CI floats to 0.10 — #142). Fix = match the code to the already-declared 0.10 API (8 lines, `loom-testing/src/emi/mod.rs`):
- `rand::thread_rng()` → `rand::rng()`
- `Rng::gen_range()` → `random_range()`
- `Box<dyn RngCore>` → `Box<dyn Rng>` (RngCore deprecated in rand_core 0.10)

Verified in an isolated target: `cargo build --release --workspace` Finished; clippy clean; fmt clean. Refs #142.

**Durable follow-up:** commit `Cargo.lock` (#142) — this is the 3rd recurrence of a gitignored-lockfile dep-float breaking CI with no code change (wasmtime 45, criterion, now rand). Recommend prioritizing before more releases.