### PR TITLE
fix(#278,#281): preserve traps in operand-discarding folds (zero-annihilation + constant-condition select)

### DIFF
--- a/loom-core/tests/issue_278_trap_preservation.rs
+++ b/loom-core/tests/issue_278_trap_preservation.rs
@@ -1,0 +1,176 @@
+//! #278 end-to-end trap-preservation: zero-annihilation / absorption folds
+//! (`x*0→0`, `0*x→0`, `x&0→0`, `x|-1→-1`, `select` with a constant condition,
+//! …) must NOT discard a TRAPPING operand.
+//!
+//! Root cause (same class as #273/#274/#276): LOOM's value-equivalence / Z3
+//! checking does not model traps. When the discarded operand is an out-of-bounds
+//! `i32.load`/`i64.load` or a `div`/`rem` by zero, the operand FAULTS at runtime;
+//! dropping it turns a trap into a returned value — a miscompile.
+//!
+//! Each case below is a module whose exported `f` computes `<trap> OP <const>`
+//! where the fold would annihilate `<trap>`. We instantiate BOTH the original
+//! and the LOOM-optimized module in wasmtime and assert they are
+//! TRAP-EQUIVALENT: the original traps (OOB / div-by-zero), so the optimized one
+//! must trap too — not return 0 / -1.
+
+use loom_core::{encode, optimize_fused_module, parse};
+use wasmtime::{Engine, Instance, Module as WtModule, Store, Val, ValType};
+
+/// Outcome of running exported `f` with no args.
+#[derive(Debug, PartialEq, Eq)]
+enum Outcome {
+    Trapped,
+    Returned(i64),
+}
+
+fn run(wasm: &[u8]) -> Outcome {
+    let engine = Engine::default();
+    let module = WtModule::new(&engine, wasm).expect("wasmtime failed to load module");
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).expect("instantiate failed");
+    let func = instance
+        .get_func(&mut store, "f")
+        .expect("export `f` missing");
+    let ty = func.ty(&store);
+    let result_ty = ty.results().next().expect("f must return a value");
+    let mut results = [match result_ty {
+        ValType::I64 => Val::I64(0),
+        _ => Val::I32(0),
+    }];
+    match func.call(&mut store, &[], &mut results) {
+        Ok(()) => match results[0] {
+            Val::I32(x) => Outcome::Returned(x as i64),
+            Val::I64(x) => Outcome::Returned(x),
+            other => panic!("unexpected result {other:?}"),
+        },
+        Err(_) => Outcome::Trapped,
+    }
+}
+
+fn optimize(wasm: &[u8]) -> Vec<u8> {
+    let mut module = parse::parse_wasm(wasm).expect("parse failed");
+    optimize_fused_module(&mut module).expect("optimize failed");
+    encode::encode_wasm(&module).expect("encode failed")
+}
+
+/// Assert: the original module TRAPS, and the optimized module TRAPS identically
+/// (i.e. the fold did NOT eliminate the trap). Also print the optimized wat so a
+/// human can confirm the trapping op survives.
+fn assert_trap_preserved(wat: &str) {
+    let orig = wat::parse_str(wat).expect("wat parse failed");
+    let opt = optimize(&orig);
+
+    let orig_outcome = run(&orig);
+    assert_eq!(
+        orig_outcome,
+        Outcome::Trapped,
+        "test fixture must trap in the ORIGINAL module; got {orig_outcome:?}"
+    );
+
+    let opt_outcome = run(&opt);
+    assert_eq!(
+        opt_outcome,
+        Outcome::Trapped,
+        "#278 REGRESSION: optimized module did NOT trap (fold discarded a \
+         trapping operand). optimized wat:\n{}",
+        wasmprinter::print_bytes(&opt).unwrap_or_default()
+    );
+}
+
+// A 1-page (64 KiB) memory; address 1_000_000 is far out of bounds.
+const MEM: &str = "(memory 1)";
+
+#[test]
+fn t278_i32_mul_load_by_zero() {
+    assert_trap_preserved(&format!(
+        "(module {MEM}(func (export \"f\")(result i32)
+            (i32.mul (i32.load (i32.const 1000000)) (i32.const 0))))"
+    ));
+}
+
+#[test]
+fn t278_i32_mul_zero_by_load() {
+    assert_trap_preserved(&format!(
+        "(module {MEM}(func (export \"f\")(result i32)
+            (i32.mul (i32.const 0) (i32.load (i32.const 1000000)))))"
+    ));
+}
+
+#[test]
+fn t278_i32_and_load_with_zero() {
+    assert_trap_preserved(&format!(
+        "(module {MEM}(func (export \"f\")(result i32)
+            (i32.and (i32.load (i32.const 1000000)) (i32.const 0))))"
+    ));
+}
+
+#[test]
+fn t278_i32_or_load_with_allones() {
+    assert_trap_preserved(&format!(
+        "(module {MEM}(func (export \"f\")(result i32)
+            (i32.or (i32.load (i32.const 1000000)) (i32.const -1))))"
+    ));
+}
+
+#[test]
+fn t278_i64_mul_load_by_zero() {
+    assert_trap_preserved(&format!(
+        "(module {MEM}(func (export \"f\")(result i64)
+            (i64.mul (i64.load (i32.const 1000000)) (i64.const 0))))"
+    ));
+}
+
+#[test]
+fn t278_i64_and_load_with_zero() {
+    assert_trap_preserved(&format!(
+        "(module {MEM}(func (export \"f\")(result i64)
+            (i64.and (i64.load (i32.const 1000000)) (i64.const 0))))"
+    ));
+}
+
+#[test]
+fn t278_i32_mul_div_by_zero_operand() {
+    // (i32.div_u 1 0) traps; multiplying it by 0 must NOT annihilate the trap.
+    assert_trap_preserved(
+        "(module (func (export \"f\")(result i32)
+            (i32.mul (i32.div_u (i32.const 1) (i32.const 0)) (i32.const 0))))",
+    );
+}
+
+#[test]
+fn t278_select_const_cond_discards_trapping_arm() {
+    // select(0, <trap>, 7) picks the false arm (7) but WASM evaluates BOTH arms,
+    // so the trapping true arm must still fault.
+    assert_trap_preserved(&format!(
+        "(module {MEM}(func (export \"f\")(result i32)
+            (select (i32.load (i32.const 1000000)) (i32.const 7) (i32.const 0))))"
+    ));
+}
+
+// ---- No over-suppression: a TRAP-FREE operand still folds to the constant ----
+
+#[test]
+fn t278_trap_free_mul_by_zero_still_folds_to_zero() {
+    let wat = "(module (func (export \"f\")(param i32)(result i32)
+        (i32.mul (local.get 0) (i32.const 0))))";
+    let orig = wat::parse_str(wat).unwrap();
+    let opt = optimize(&orig);
+    let opt_wat = wasmprinter::print_bytes(&opt).unwrap();
+    // The trap-free operand must be discarded and folded away: no i32.mul / no
+    // local.get survives — the body is just `i32.const 0`.
+    assert!(
+        !opt_wat.contains("i32.mul") && !opt_wat.contains("local.get"),
+        "trap-free (local.get 0)*0 must fold to a constant, got:\n{opt_wat}"
+    );
+
+    // And it must actually behave as 0 for any argument.
+    let engine = Engine::default();
+    let module = WtModule::new(&engine, &opt).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+    let func = instance.get_func(&mut store, "f").unwrap();
+    let mut results = [Val::I32(123)];
+    func.call(&mut store, &[Val::I32(999)], &mut results)
+        .unwrap();
+    assert_eq!(results[0].i32(), Some(0), "folded x*0 must yield 0");
+}

--- a/loom-core/tests/issue_278_trap_preservation.rs
+++ b/loom-core/tests/issue_278_trap_preservation.rs
@@ -13,7 +13,7 @@
 //! TRAP-EQUIVALENT: the original traps (OOB / div-by-zero), so the optimized one
 //! must trap too — not return 0 / -1.
 
-use loom_core::{encode, optimize_fused_module, parse};
+use loom_core::{encode, optimize, parse};
 use wasmtime::{Engine, Instance, Module as WtModule, Store, Val, ValType};
 
 /// Outcome of running exported `f` with no args.
@@ -48,8 +48,13 @@ fn run(wasm: &[u8]) -> Outcome {
 }
 
 fn optimize(wasm: &[u8]) -> Vec<u8> {
+    // The zero-annihilation / absorption / constant-condition-`select` folds
+    // gated by #278 live in the algebraic simplifier that `constant_folding`
+    // drives (ISLE `rewrite_pure` over the term IR). The component-fusion
+    // pipeline (`optimize_fused_module`) does adapter devirt / dedup / DCE only
+    // and never touches this arithmetic, so it could not exercise the gate.
     let mut module = parse::parse_wasm(wasm).expect("parse failed");
-    optimize_fused_module(&mut module).expect("optimize failed");
+    optimize::constant_folding(&mut module).expect("optimize failed");
     encode::encode_wasm(&module).expect("encode failed")
 }
 

--- a/loom-core/tests/issue_281_select_trap.rs
+++ b/loom-core/tests/issue_281_select_trap.rs
@@ -1,0 +1,167 @@
+//! #281 end-to-end trap-preservation for the constant-condition `select` fold.
+//!
+//! gale #281: `loom optimize` folded `select(const_cond, a, b)` to the taken
+//! arm, DISCARDING the other arm. But WASM `select` is EAGER — BOTH value
+//! operands are evaluated before the condition selects one (WASM Core §4.4.1) —
+//! so if the DISCARDED arm contains a trapping op (out-of-bounds load, div, …),
+//! dropping it silently deletes a trap: a miscompile.
+//!
+//! Fix (shared with #278): the constant-condition select fold in the algebraic
+//! simplifier is gated on the DISCARDED arm being provably trap-free
+//! (`is_no_trap_expr`, the `is_forwardable_expr` whitelist). If the discarded
+//! arm may trap, the `select` is kept intact and the trap is preserved.
+//!
+//! These cases exercise the fold via `constant_folding` — the pass that drives
+//! the ISLE `rewrite_pure` term simplifier where the constant-condition select
+//! fold lives. We cover the trapping op being on EITHER discarded side, and
+//! confirm a trap-free discarded arm STILL folds.
+
+use loom_core::{encode, optimize, parse};
+use wasmtime::{Engine, Instance, Module as WtModule, Store, Val};
+
+#[derive(Debug, PartialEq, Eq)]
+enum Outcome {
+    Trapped,
+    Returned(i32),
+}
+
+fn run(wasm: &[u8]) -> Outcome {
+    let engine = Engine::default();
+    let module = WtModule::new(&engine, wasm).expect("wasmtime failed to load module");
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).expect("instantiate failed");
+    let func = instance
+        .get_func(&mut store, "f")
+        .expect("export `f` missing");
+    let mut results = [Val::I32(0)];
+    match func.call(&mut store, &[], &mut results) {
+        Ok(()) => match results[0] {
+            Val::I32(x) => Outcome::Returned(x),
+            other => panic!("unexpected result {other:?}"),
+        },
+        Err(_) => Outcome::Trapped,
+    }
+}
+
+fn optimize_wasm(wasm: &[u8]) -> Vec<u8> {
+    let mut module = parse::parse_wasm(wasm).expect("parse failed");
+    optimize::constant_folding(&mut module).expect("optimize failed");
+    encode::encode_wasm(&module).expect("encode failed")
+}
+
+/// The original module traps (the trapping op is reached under WASM's eager
+/// evaluation of both select arms). Assert the optimized module ALSO traps —
+/// i.e. the constant-condition fold did NOT discard the trapping arm.
+fn assert_trap_preserved(wat: &str) {
+    let orig = wat::parse_str(wat).expect("wat parse failed");
+    assert_eq!(
+        run(&orig),
+        Outcome::Trapped,
+        "fixture must trap in the ORIGINAL module"
+    );
+
+    let opt = optimize_wasm(&orig);
+    let opt_outcome = run(&opt);
+    assert_eq!(
+        opt_outcome,
+        Outcome::Trapped,
+        "#281 REGRESSION: optimized module did NOT trap (constant-condition \
+         select fold discarded a trapping arm). optimized wat:\n{}",
+        wasmprinter::print_bytes(&opt).unwrap_or_default()
+    );
+}
+
+// 1-page (64 KiB) memory; address 1_000_000 is far out of bounds → i32.load traps.
+const MEM: &str = "(memory 1)";
+
+#[test]
+fn t281_true_const_discards_trapping_false_arm() {
+    // select(true=7, false=load_OOB, cond=1): cond!=0 picks the TRUE arm (7),
+    // but WASM already evaluated the false arm (load_OOB) → traps. The fold must
+    // NOT drop the discarded (false) load arm.
+    assert_trap_preserved(&format!(
+        "(module {MEM}(func (export \"f\")(result i32)
+            (select (i32.const 7) (i32.load (i32.const 1000000)) (i32.const 1))))"
+    ));
+}
+
+#[test]
+fn t281_false_const_discards_trapping_true_arm() {
+    // select(true=load_OOB, false=7, cond=0): cond==0 picks the FALSE arm (7),
+    // but the true arm (load_OOB) is still evaluated → traps. The fold must NOT
+    // drop the discarded (true) load arm.
+    assert_trap_preserved(&format!(
+        "(module {MEM}(func (export \"f\")(result i32)
+            (select (i32.load (i32.const 1000000)) (i32.const 7) (i32.const 0))))"
+    ));
+}
+
+#[test]
+fn t281_true_const_discards_trapping_div_false_arm() {
+    // Non-memory trap: (i32.div_u 1 0) in the discarded false arm must survive.
+    assert_trap_preserved(
+        "(module (func (export \"f\")(result i32)
+            (select (i32.const 7) (i32.div_u (i32.const 1) (i32.const 0)) (i32.const 1))))",
+    );
+}
+
+// ---- No over-suppression: a trap-free discarded arm STILL folds away ----
+
+#[test]
+fn t281_trap_free_arms_fold_to_taken() {
+    // select(true=local.get 0, false=local.get 1, cond=1) → local.get 0.
+    // Both arms are trap-free (locals), so the fold is sound: no `select`
+    // survives and the taken arm is the whole body.
+    let wat = "(module (func (export \"f\")(param i32 i32)(result i32)
+        (select (local.get 0) (local.get 1) (i32.const 1))))";
+    let orig = wat::parse_str(wat).unwrap();
+    let opt = optimize_wasm(&orig);
+    let opt_wat = wasmprinter::print_bytes(&opt).unwrap();
+    assert!(
+        !opt_wat.contains("select"),
+        "trap-free select(1, a, b) must fold to `a` (no select left), got:\n{opt_wat}"
+    );
+
+    // And it must actually return the taken (true) arm's value.
+    let engine = Engine::default();
+    let module = WtModule::new(&engine, &opt).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+    let func = instance.get_func(&mut store, "f").unwrap();
+    let mut results = [Val::I32(0)];
+    func.call(&mut store, &[Val::I32(11), Val::I32(22)], &mut results)
+        .unwrap();
+    assert_eq!(
+        results[0].i32(),
+        Some(11),
+        "folded select(1, a, b) must yield the true arm `a`"
+    );
+}
+
+#[test]
+fn t281_trap_free_false_cond_folds_to_false_arm() {
+    // select(true=local.get 0, false=local.get 1, cond=0) → local.get 1.
+    let wat = "(module (func (export \"f\")(param i32 i32)(result i32)
+        (select (local.get 0) (local.get 1) (i32.const 0))))";
+    let orig = wat::parse_str(wat).unwrap();
+    let opt = optimize_wasm(&orig);
+    let opt_wat = wasmprinter::print_bytes(&opt).unwrap();
+    assert!(
+        !opt_wat.contains("select"),
+        "trap-free select(0, a, b) must fold to `b` (no select left), got:\n{opt_wat}"
+    );
+
+    let engine = Engine::default();
+    let module = WtModule::new(&engine, &opt).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+    let func = instance.get_func(&mut store, "f").unwrap();
+    let mut results = [Val::I32(0)];
+    func.call(&mut store, &[Val::I32(11), Val::I32(22)], &mut results)
+        .unwrap();
+    assert_eq!(
+        results[0].i32(),
+        Some(22),
+        "folded select(0, a, b) must yield the false arm `b`"
+    );
+}

--- a/loom-shared/src/lib.rs
+++ b/loom-shared/src/lib.rs
@@ -2867,6 +2867,26 @@ fn is_forwardable_expr(v: &Value) -> bool {
     }
 }
 
+/// #278: is `v` provably TRAP-FREE, so that DISCARDING it (dropping the operand
+/// entirely) preserves observable semantics? A trapping operand — an
+/// out-of-bounds memory load/store, an integer div/rem (traps on 0 / INT_MIN÷-1),
+/// an `unreachable`, a call (callees can trap), a trapping float→int truncate,
+/// etc. — must NOT be discarded, or the optimized module would return a value
+/// where the original TRAPS.
+///
+/// Zero-annihilation / absorption identities (`x*0→0`, `0*x→0`, `x&0→0`,
+/// `x|-1→-1`, a `select`'s untaken arm, …) throw away a whole operand subtree.
+/// LOOM's value-equivalence / Z3 checking does not model traps (#273/#274/#276),
+/// so these folds are only sound when the discarded operand cannot trap. This is
+/// exactly the `is_forwardable_expr` whitelist: constants, locals, globals, and
+/// total pure integer arithmetic / bitwise / shift / rotate / compare /
+/// width-convert / select over trap-free operands. Loads/stores, div/rem, calls,
+/// unreachable, floats, and every unknown/impure variant are NOT on the whitelist
+/// and are conservatively treated as MAY-trap (→ do not discard).
+fn is_no_trap_expr(v: &Value) -> bool {
+    is_forwardable_expr(v)
+}
+
 /// #219: does `v` (a forwardable expr — same whitelist as `is_forwardable_expr`)
 /// reference `local.get local_idx`? Used to INVALIDATE a pinned forwarding when
 /// one of its input locals is reassigned (reaching-defs guard), so a forwarded
@@ -3801,10 +3821,19 @@ fn rewrite_pure_impl(val: Value) -> Value {
                 (ValueData::I32Const { val: lhs_val }, ValueData::I32Const { val: rhs_val }) => {
                     iconst32(imm32_mul(*lhs_val, *rhs_val))
                 }
-                // Algebraic: x * 0 = 0
-                (_, ValueData::I32Const { val }) if val.value() == 0 => iconst32(Imm32(0)),
-                // Algebraic: 0 * x = 0
-                (ValueData::I32Const { val }, _) if val.value() == 0 => iconst32(Imm32(0)),
+                // Algebraic: x * 0 = 0 — only when the DISCARDED `x` cannot trap
+                // (#278: a trapping load/div in x must still fault).
+                (_, ValueData::I32Const { val })
+                    if val.value() == 0 && is_no_trap_expr(&lhs_simplified) =>
+                {
+                    iconst32(Imm32(0))
+                }
+                // Algebraic: 0 * x = 0 — only when the DISCARDED `x` cannot trap.
+                (ValueData::I32Const { val }, _)
+                    if val.value() == 0 && is_no_trap_expr(&rhs_simplified) =>
+                {
+                    iconst32(Imm32(0))
+                }
                 // Algebraic: x * 1 = x
                 (_, ValueData::I32Const { val }) if val.value() == 1 => lhs_simplified,
                 // Algebraic: 1 * x = x
@@ -3893,8 +3922,18 @@ fn rewrite_pure_impl(val: Value) -> Value {
                 (ValueData::I64Const { val: lhs_val }, ValueData::I64Const { val: rhs_val }) => {
                     iconst64(imm64_mul(*lhs_val, *rhs_val))
                 }
-                (_, ValueData::I64Const { val }) if val.value() == 0 => iconst64(Imm64(0)),
-                (ValueData::I64Const { val }, _) if val.value() == 0 => iconst64(Imm64(0)),
+                // Algebraic: x * 0 = 0 / 0 * x = 0 — only when the DISCARDED
+                // operand cannot trap (#278).
+                (_, ValueData::I64Const { val })
+                    if val.value() == 0 && is_no_trap_expr(&lhs_simplified) =>
+                {
+                    iconst64(Imm64(0))
+                }
+                (ValueData::I64Const { val }, _)
+                    if val.value() == 0 && is_no_trap_expr(&rhs_simplified) =>
+                {
+                    iconst64(Imm64(0))
+                }
                 (_, ValueData::I64Const { val }) if val.value() == 1 => lhs_simplified,
                 (ValueData::I64Const { val }, _) if val.value() == 1 => rhs_simplified,
                 // Algebraic: x * -1 = 0 - x (negate)
@@ -3977,9 +4016,18 @@ fn rewrite_pure_impl(val: Value) -> Value {
                 (ValueData::I32Const { val: lhs_val }, ValueData::I32Const { val: rhs_val }) => {
                     iconst32(imm32_and(*lhs_val, *rhs_val))
                 }
-                // Algebraic: x & 0 = 0
-                (_, ValueData::I32Const { val }) if val.value() == 0 => iconst32(Imm32(0)),
-                (ValueData::I32Const { val }, _) if val.value() == 0 => iconst32(Imm32(0)),
+                // Algebraic: x & 0 = 0 — only when the DISCARDED operand cannot
+                // trap (#278).
+                (_, ValueData::I32Const { val })
+                    if val.value() == 0 && is_no_trap_expr(&lhs_simplified) =>
+                {
+                    iconst32(Imm32(0))
+                }
+                (ValueData::I32Const { val }, _)
+                    if val.value() == 0 && is_no_trap_expr(&rhs_simplified) =>
+                {
+                    iconst32(Imm32(0))
+                }
                 // Algebraic: x & -1 = x (all bits set)
                 (_, ValueData::I32Const { val }) if val.value() == -1 => lhs_simplified,
                 (ValueData::I32Const { val }, _) if val.value() == -1 => rhs_simplified,
@@ -4017,9 +4065,18 @@ fn rewrite_pure_impl(val: Value) -> Value {
                 // Algebraic: x | 0 = x
                 (_, ValueData::I32Const { val }) if val.value() == 0 => lhs_simplified,
                 (ValueData::I32Const { val }, _) if val.value() == 0 => rhs_simplified,
-                // Algebraic: x | -1 = -1 (all bits set)
-                (_, ValueData::I32Const { val }) if val.value() == -1 => iconst32(Imm32(-1)),
-                (ValueData::I32Const { val }, _) if val.value() == -1 => iconst32(Imm32(-1)),
+                // Algebraic: x | -1 = -1 (all bits set) — only when the DISCARDED
+                // operand cannot trap (#278).
+                (_, ValueData::I32Const { val })
+                    if val.value() == -1 && is_no_trap_expr(&lhs_simplified) =>
+                {
+                    iconst32(Imm32(-1))
+                }
+                (ValueData::I32Const { val }, _)
+                    if val.value() == -1 && is_no_trap_expr(&rhs_simplified) =>
+                {
+                    iconst32(Imm32(-1))
+                }
                 _ => ior32(lhs_simplified, rhs_simplified),
             }
         }
@@ -4148,9 +4205,18 @@ fn rewrite_pure_impl(val: Value) -> Value {
                 (ValueData::I64Const { val: lhs_val }, ValueData::I64Const { val: rhs_val }) => {
                     iconst64(imm64_and(*lhs_val, *rhs_val))
                 }
-                // Algebraic: x & 0 = 0
-                (_, ValueData::I64Const { val }) if val.value() == 0 => iconst64(Imm64(0)),
-                (ValueData::I64Const { val }, _) if val.value() == 0 => iconst64(Imm64(0)),
+                // Algebraic: x & 0 = 0 — only when the DISCARDED operand cannot
+                // trap (#278).
+                (_, ValueData::I64Const { val })
+                    if val.value() == 0 && is_no_trap_expr(&lhs_simplified) =>
+                {
+                    iconst64(Imm64(0))
+                }
+                (ValueData::I64Const { val }, _)
+                    if val.value() == 0 && is_no_trap_expr(&rhs_simplified) =>
+                {
+                    iconst64(Imm64(0))
+                }
                 // Algebraic: x & -1 = x (all bits set)
                 (_, ValueData::I64Const { val }) if val.value() == -1 => lhs_simplified,
                 (ValueData::I64Const { val }, _) if val.value() == -1 => rhs_simplified,
@@ -4160,13 +4226,17 @@ fn rewrite_pure_impl(val: Value) -> Value {
                 // bits [k,64), so nothing survives. Unconditionally sound for
                 // any Z (Z3: (Z<<k) & M == 0 when M >> k == 0). Dissolves the
                 // high half of a u64 pack under a low-byte unpack mask.
+                // #278: the whole `(shl Z k)` operand is DISCARDED, so only fire
+                // when Z (and thus the shl) cannot trap.
                 (ValueData::I64Shl { .. }, ValueData::I64Const { val: m })
-                    if i64_shl_cleared_by_mask(&lhs_simplified, m) =>
+                    if i64_shl_cleared_by_mask(&lhs_simplified, m)
+                        && is_no_trap_expr(&lhs_simplified) =>
                 {
                     iconst64(Imm64(0))
                 }
                 (ValueData::I64Const { val: m }, ValueData::I64Shl { .. })
-                    if i64_shl_cleared_by_mask(&rhs_simplified, m) =>
+                    if i64_shl_cleared_by_mask(&rhs_simplified, m)
+                        && is_no_trap_expr(&rhs_simplified) =>
                 {
                     iconst64(Imm64(0))
                 }
@@ -4188,16 +4258,22 @@ fn rewrite_pure_impl(val: Value) -> Value {
                 // #219 seam-SROA: (or A B) & M → (survivor & M) when one OR
                 // operand is a left shift the mask clears. Recurse so the
                 // survivor (and a both-shifted case) simplifies further.
+                // #278: the CLEARED operand is DISCARDED, so only fire when it
+                // cannot trap.
                 (ValueData::I64Or { lhs: a, rhs: b }, ValueData::I64Const { val: m })
-                    if i64_shl_cleared_by_mask(a, m) || i64_shl_cleared_by_mask(b, m) =>
+                    if (i64_shl_cleared_by_mask(a, m) && is_no_trap_expr(a))
+                        || (i64_shl_cleared_by_mask(b, m) && is_no_trap_expr(b)) =>
                 {
-                    let survivor = if i64_shl_cleared_by_mask(a, m) { b } else { a };
+                    let cleared_a = i64_shl_cleared_by_mask(a, m) && is_no_trap_expr(a);
+                    let survivor = if cleared_a { b } else { a };
                     rewrite_pure(iand64(survivor.clone(), iconst64(*m)))
                 }
                 (ValueData::I64Const { val: m }, ValueData::I64Or { lhs: a, rhs: b })
-                    if i64_shl_cleared_by_mask(a, m) || i64_shl_cleared_by_mask(b, m) =>
+                    if (i64_shl_cleared_by_mask(a, m) && is_no_trap_expr(a))
+                        || (i64_shl_cleared_by_mask(b, m) && is_no_trap_expr(b)) =>
                 {
-                    let survivor = if i64_shl_cleared_by_mask(a, m) { b } else { a };
+                    let cleared_a = i64_shl_cleared_by_mask(a, m) && is_no_trap_expr(a);
+                    let survivor = if cleared_a { b } else { a };
                     rewrite_pure(iand64(survivor.clone(), iconst64(*m)))
                 }
                 // #240: (x & c1) & c2 → x & (c1 & c2) (see i32 note). Associative
@@ -4231,9 +4307,18 @@ fn rewrite_pure_impl(val: Value) -> Value {
                 // Algebraic: x | 0 = x
                 (_, ValueData::I64Const { val }) if val.value() == 0 => lhs_simplified,
                 (ValueData::I64Const { val }, _) if val.value() == 0 => rhs_simplified,
-                // Algebraic: x | -1 = -1 (all bits set)
-                (_, ValueData::I64Const { val }) if val.value() == -1 => iconst64(Imm64(-1)),
-                (ValueData::I64Const { val }, _) if val.value() == -1 => iconst64(Imm64(-1)),
+                // Algebraic: x | -1 = -1 (all bits set) — only when the DISCARDED
+                // operand cannot trap (#278).
+                (_, ValueData::I64Const { val })
+                    if val.value() == -1 && is_no_trap_expr(&lhs_simplified) =>
+                {
+                    iconst64(Imm64(-1))
+                }
+                (ValueData::I64Const { val }, _)
+                    if val.value() == -1 && is_no_trap_expr(&rhs_simplified) =>
+                {
+                    iconst64(Imm64(-1))
+                }
                 _ => ior64(lhs_simplified, rhs_simplified),
             }
         }
@@ -4938,16 +5023,28 @@ fn rewrite_pure_impl(val: Value) -> Value {
             let true_simplified = rewrite_pure(true_val.clone());
             let false_simplified = rewrite_pure(false_val.clone());
 
-            // Algebraic: select(c, x, x) → x (both branches same)
-            if are_values_equal(&true_simplified, &false_simplified) {
+            // Algebraic: select(c, x, x) → x (both branches same).
+            // #278: WASM `select` evaluates ALL three operands, so the DISCARDED
+            // condition `c` must be trap-free to drop it.
+            if are_values_equal(&true_simplified, &false_simplified)
+                && is_no_trap_expr(&cond_simplified)
+            {
                 return true_simplified;
             }
 
             match cond_simplified.data() {
-                // Constant folding: (select (i32.const 0) true false) → false
-                ValueData::I32Const { val } if val.value() == 0 => false_simplified,
-                // Constant folding: (select (i32.const N) true false) → true (N != 0)
-                ValueData::I32Const { .. } => true_simplified,
+                // Constant folding: (select (i32.const 0) true false) → false.
+                // #278: the untaken `true` arm is DISCARDED but WASM still
+                // evaluates it, so it must be trap-free to drop it.
+                ValueData::I32Const { val }
+                    if val.value() == 0 && is_no_trap_expr(&true_simplified) =>
+                {
+                    false_simplified
+                }
+                // Constant folding: (select (i32.const N) true false) → true
+                // (N != 0). #278: the untaken `false` arm is DISCARDED but still
+                // evaluated by WASM, so it must be trap-free to drop it.
+                ValueData::I32Const { .. } if is_no_trap_expr(&false_simplified) => true_simplified,
                 _ => select_instr(cond_simplified, true_simplified, false_simplified),
             }
         }
@@ -6721,6 +6818,285 @@ mod tests {
             !matches!(out.data(), ValueData::LocalGet { .. }),
             "an insufficient bound must not license the fold, got {:?}",
             out.data()
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // #278: zero-annihilation / absorption folds must NOT discard a TRAPPING
+    // operand. A discarded out-of-bounds load / div-by-zero would silently
+    // eliminate a mandatory WASM trap, returning a value where the original
+    // module traps. Below, an OOB `i32.load`/`i64.load` and a `div` stand in for
+    // "may-trap"; a `local.get` stands in for "provably trap-free".
+    // -------------------------------------------------------------------------
+
+    /// A load anywhere in the tree that stands for an OOB access.
+    fn tree_contains_load(v: &Value) -> bool {
+        match v.data() {
+            ValueData::I32Load { .. }
+            | ValueData::I64Load { .. }
+            | ValueData::I32DivS { .. }
+            | ValueData::I32DivU { .. }
+            | ValueData::I64DivS { .. }
+            | ValueData::I64DivU { .. } => true,
+            ValueData::I32Mul { lhs, rhs }
+            | ValueData::I32And { lhs, rhs }
+            | ValueData::I32Or { lhs, rhs }
+            | ValueData::I64Mul { lhs, rhs }
+            | ValueData::I64And { lhs, rhs }
+            | ValueData::I64Or { lhs, rhs }
+            | ValueData::I64Shl { lhs, rhs } => tree_contains_load(lhs) || tree_contains_load(rhs),
+            ValueData::Select {
+                cond,
+                true_val,
+                false_val,
+            } => {
+                tree_contains_load(cond)
+                    || tree_contains_load(true_val)
+                    || tree_contains_load(false_val)
+            }
+            _ => false,
+        }
+    }
+
+    fn oob_i32_load() -> Value {
+        // i32.load at a huge constant address — OOB in any small memory.
+        i32_load(iconst32(Imm32::from(1_000_000)), 0, 2, 0)
+    }
+    fn oob_i64_load() -> Value {
+        i64_load(iconst64(Imm64::from(1_000_000)), 0, 3, 0)
+    }
+    fn trapping_div() -> Value {
+        // (i32.div_u (i32.const 1) (i32.const 0)) — div-by-zero trap.
+        idivu32(iconst32(Imm32::from(1)), iconst32(Imm32::from(0)))
+    }
+
+    #[test]
+    fn test_278_i32_mul_by_zero_keeps_trapping_load() {
+        // (i32.mul (i32.load OOB) (i32.const 0)) must NOT fold to 0.
+        let a = rewrite_pure(imul32(oob_i32_load(), iconst32(Imm32::from(0))));
+        assert!(
+            tree_contains_load(&a),
+            "x*0 dropped a trapping load: {:?}",
+            a.data()
+        );
+        // Reversed operand order: (i32.mul (i32.const 0) (i32.load OOB)).
+        let b = rewrite_pure(imul32(iconst32(Imm32::from(0)), oob_i32_load()));
+        assert!(
+            tree_contains_load(&b),
+            "0*x dropped a trapping load: {:?}",
+            b.data()
+        );
+    }
+
+    #[test]
+    fn test_278_i32_mul_by_zero_keeps_trapping_div() {
+        let a = rewrite_pure(imul32(trapping_div(), iconst32(Imm32::from(0))));
+        assert!(
+            tree_contains_load(&a),
+            "x*0 dropped a trapping div: {:?}",
+            a.data()
+        );
+    }
+
+    #[test]
+    fn test_278_i64_mul_by_zero_keeps_trapping_load() {
+        let a = rewrite_pure(imul64(oob_i64_load(), iconst64(Imm64::from(0))));
+        assert!(
+            tree_contains_load(&a),
+            "i64 x*0 dropped a trapping load: {:?}",
+            a.data()
+        );
+        let b = rewrite_pure(imul64(iconst64(Imm64::from(0)), oob_i64_load()));
+        assert!(
+            tree_contains_load(&b),
+            "i64 0*x dropped a trapping load: {:?}",
+            b.data()
+        );
+    }
+
+    #[test]
+    fn test_278_i32_and_zero_keeps_trapping_load() {
+        let a = rewrite_pure(iand32(oob_i32_load(), iconst32(Imm32::from(0))));
+        assert!(
+            tree_contains_load(&a),
+            "x&0 dropped a trapping load: {:?}",
+            a.data()
+        );
+        let b = rewrite_pure(iand32(iconst32(Imm32::from(0)), oob_i32_load()));
+        assert!(
+            tree_contains_load(&b),
+            "0&x dropped a trapping load: {:?}",
+            b.data()
+        );
+    }
+
+    #[test]
+    fn test_278_i64_and_zero_keeps_trapping_load() {
+        let a = rewrite_pure(iand64(oob_i64_load(), iconst64(Imm64::from(0))));
+        assert!(
+            tree_contains_load(&a),
+            "i64 x&0 dropped a trapping load: {:?}",
+            a.data()
+        );
+        let b = rewrite_pure(iand64(iconst64(Imm64::from(0)), oob_i64_load()));
+        assert!(
+            tree_contains_load(&b),
+            "i64 0&x dropped a trapping load: {:?}",
+            b.data()
+        );
+    }
+
+    #[test]
+    fn test_278_i32_or_allones_keeps_trapping_load() {
+        // (i32.or (i32.load OOB) (i32.const -1)) must NOT fold to -1.
+        let a = rewrite_pure(ior32(oob_i32_load(), iconst32(Imm32::from(-1))));
+        assert!(
+            tree_contains_load(&a),
+            "x|-1 dropped a trapping load: {:?}",
+            a.data()
+        );
+        let b = rewrite_pure(ior32(iconst32(Imm32::from(-1)), oob_i32_load()));
+        assert!(
+            tree_contains_load(&b),
+            "-1|x dropped a trapping load: {:?}",
+            b.data()
+        );
+    }
+
+    #[test]
+    fn test_278_i64_or_allones_keeps_trapping_load() {
+        let a = rewrite_pure(ior64(oob_i64_load(), iconst64(Imm64::from(-1))));
+        assert!(
+            tree_contains_load(&a),
+            "i64 x|-1 dropped a trapping load: {:?}",
+            a.data()
+        );
+        let b = rewrite_pure(ior64(iconst64(Imm64::from(-1)), oob_i64_load()));
+        assert!(
+            tree_contains_load(&b),
+            "i64 -1|x dropped a trapping load: {:?}",
+            b.data()
+        );
+    }
+
+    #[test]
+    fn test_278_select_const_cond_keeps_trapping_untaken_arm() {
+        // select(0, trap, safe) → safe would DROP the trapping `true` arm.
+        let a = rewrite_pure(select_instr(
+            iconst32(Imm32::from(0)),
+            oob_i32_load(),
+            iconst32(Imm32::from(7)),
+        ));
+        assert!(
+            tree_contains_load(&a),
+            "select(0,..) dropped trapping true arm: {:?}",
+            a.data()
+        );
+        // select(1, safe, trap) → safe would DROP the trapping `false` arm.
+        let b = rewrite_pure(select_instr(
+            iconst32(Imm32::from(1)),
+            iconst32(Imm32::from(7)),
+            oob_i32_load(),
+        ));
+        assert!(
+            tree_contains_load(&b),
+            "select(1,..) dropped trapping false arm: {:?}",
+            b.data()
+        );
+    }
+
+    #[test]
+    fn test_278_select_same_arms_keeps_trapping_cond() {
+        // select(trap_cond, x, x) → x would DROP the trapping condition.
+        let out = rewrite_pure(select_instr(
+            oob_i32_load(),
+            iconst32(Imm32::from(5)),
+            iconst32(Imm32::from(5)),
+        ));
+        assert!(
+            tree_contains_load(&out),
+            "select(c,x,x) dropped trapping cond: {:?}",
+            out.data()
+        );
+    }
+
+    // ---- No over-suppression: trap-FREE operands STILL fold ------------------
+
+    #[test]
+    fn test_278_trap_free_mul_by_zero_still_folds() {
+        // (local.get 0) * 0 → 0 (local.get cannot trap).
+        let out = rewrite_pure(imul32(local_get(0), iconst32(Imm32::from(0))));
+        assert!(
+            matches!(out.data(), ValueData::I32Const { val } if val.value() == 0),
+            "trap-free x*0 must still fold to 0, got {:?}",
+            out.data()
+        );
+        let out2 = rewrite_pure(imul32(iconst32(Imm32::from(0)), local_get(0)));
+        assert!(
+            matches!(out2.data(), ValueData::I32Const { val } if val.value() == 0),
+            "trap-free 0*x must still fold to 0, got {:?}",
+            out2.data()
+        );
+    }
+
+    #[test]
+    fn test_278_trap_free_and_zero_still_folds() {
+        let out = rewrite_pure(iand32(local_get(0), iconst32(Imm32::from(0))));
+        assert!(
+            matches!(out.data(), ValueData::I32Const { val } if val.value() == 0),
+            "trap-free x&0 must still fold to 0, got {:?}",
+            out.data()
+        );
+    }
+
+    #[test]
+    fn test_278_trap_free_or_allones_still_folds() {
+        let out = rewrite_pure(ior32(local_get(0), iconst32(Imm32::from(-1))));
+        assert!(
+            matches!(out.data(), ValueData::I32Const { val } if val.value() == -1),
+            "trap-free x|-1 must still fold to -1, got {:?}",
+            out.data()
+        );
+    }
+
+    #[test]
+    fn test_278_trap_free_i64_still_folds() {
+        let m = rewrite_pure(imul64(local_get(0), iconst64(Imm64::from(0))));
+        assert!(
+            matches!(m.data(), ValueData::I64Const { val } if val.value() == 0),
+            "trap-free i64 x*0 must still fold, got {:?}",
+            m.data()
+        );
+        let a = rewrite_pure(iand64(local_get(0), iconst64(Imm64::from(0))));
+        assert!(
+            matches!(a.data(), ValueData::I64Const { val } if val.value() == 0),
+            "trap-free i64 x&0 must still fold, got {:?}",
+            a.data()
+        );
+    }
+
+    #[test]
+    fn test_278_trap_free_select_still_folds() {
+        // Both arms trap-free constants; select(0,7,9) → 9, select(1,7,9) → 7.
+        let f = rewrite_pure(select_instr(
+            iconst32(Imm32::from(0)),
+            iconst32(Imm32::from(7)),
+            iconst32(Imm32::from(9)),
+        ));
+        assert!(
+            matches!(f.data(), ValueData::I32Const { val } if val.value() == 9),
+            "trap-free select(0,..) must fold to false arm, got {:?}",
+            f.data()
+        );
+        let t = rewrite_pure(select_instr(
+            iconst32(Imm32::from(1)),
+            iconst32(Imm32::from(7)),
+            iconst32(Imm32::from(9)),
+        ));
+        assert!(
+            matches!(t.data(), ValueData::I32Const { val } if val.value() == 7),
+            "trap-free select(1,..) must fold to true arm, got {:?}",
+            t.data()
         );
     }
 }


### PR DESCRIPTION
Fixes #278. Fixes #281. Two trap-elimination miscompiles of the operand-discarding class.

**#278** — `x*0→0`/`0*x→0`/`x&0→0` discarded a trapping operand (OOB load, div). **#281** — constant-condition `select(const,a,b)` dropped the non-taken arm (WASM select is EAGER — both arms evaluated). Both are gated on the discarded operand/arm being trap-free (`is_no_trap_expr`, reused not duplicated): trap-free operands still fold; may-trap operands keep the op so the trap is preserved.

Verified behaviorally via wasmtime (trap outcome matches original) on both arms for select, and OOB-load / div-by-zero for annihilation. #278 suite 9 green, #281 suite 5 green, full workspace green, clippy clean. (Note: the earlier test harness ran the fusion pipeline which never applies these folds — repointed to `constant_folding` so the tests actually exercise + prove the gates.)

Last of the per-identity trap stopgaps — the systemic cure is loom#279 (v1.2.1). Folds into v1.2.0.