### PR TITLE
feat(#277 Tier-1): migrate rule verifier to ordeal behind a swappable solver trait (57/57 differential)

### DIFF
--- a/loom-core/examples/verify_rules_demo.rs
+++ b/loom-core/examples/verify_rules_demo.rs
@@ -1,18 +1,28 @@
-//! Demonstration of Z3-based optimization rule verification
+//! Demonstration of optimization rule verification.
 //!
-//! This shows how LOOM uses Z3 to PROVE optimization rules are correct
-//! for ALL possible inputs, rather than just testing specific cases.
+//! This shows how LOOM PROVES optimization rules are correct for ALL possible
+//! inputs, rather than just testing specific cases.
+//!
+//! The proof backend is swappable (issue #277) via `LOOM_VERIFY_BACKEND`:
+//!   * `z3`     — Z3 (default)
+//!   * `ordeal` — the pure-Rust, certificate-checked QF_BV solver
+//!   * `both`   — run both and assert the verdicts AGREE (differential burn-in)
 //!
 //! Run with: cargo run --example verify_rules_demo --features verification
+//!       or: LOOM_VERIFY_BACKEND=both cargo run --example verify_rules_demo --features verification
 
+use loom_core::rule_solver::active_solver;
 use loom_core::verify_rules::*;
 
 fn main() {
+    let backend = active_solver().backend_name();
+
     println!("╔══════════════════════════════════════════════════════════════════╗");
-    println!("║       LOOM Z3 Optimization Rule Verification                     ║");
+    println!("║       LOOM Optimization Rule Verification                        ║");
     println!("║       Proving Correctness for ALL Inputs                         ║");
     println!("╚══════════════════════════════════════════════════════════════════╝\n");
 
+    println!("Proof backend: {backend}  (set LOOM_VERIFY_BACKEND=z3|ordeal|both)");
     println!("Each proof below covers ALL possible values (2³² for i32, 2⁶⁴ for i64)");
     println!("This is equivalent to running billions of test cases instantly.\n");
 

--- a/loom-core/src/lib.rs
+++ b/loom-core/src/lib.rs
@@ -15424,6 +15424,15 @@ pub mod verify;
 /// hypothesis" machinery that #231 (proof-carrying facts) will reuse.
 pub mod trap_gate;
 
+/// Swappable solver backend for algebraic rule verification (issue #277).
+///
+/// Defines the backend-neutral term DSL and the `RuleSolver` trait that
+/// `verify_rules` discharges its proof obligations through, with Z3 and
+/// `ordeal` (certificate-checked QF_BV) implementations selected via
+/// `LOOM_VERIFY_BACKEND`. This is the migration boundary for moving rule
+/// verification off Z3 onto ordeal; Tier-2 (`verify`) grows the same seam later.
+pub mod rule_solver;
+
 /// Optimization rule verification using Z3
 ///
 /// This module provides formal proofs that individual optimization rules are

--- a/loom-core/src/rule_solver.rs
+++ b/loom-core/src/rule_solver.rs
@@ -1,0 +1,675 @@
+// The Z3 backend's fluent builder takes borrowed args (`&lower(b)`); this is the
+// idiomatic Z3 pattern and matches `verify_rules.rs`.
+#![allow(clippy::needless_borrows_for_generic_args)]
+
+//! Swappable solver backend for algebraic rule verification (issue #277).
+//!
+//! `verify_rules.rs` proves LOOM's algebraic rewrite rules correct: for each
+//! rule it builds an LHS and an RHS bitvector term, asserts they are NOT equal,
+//! and expects `Unsat` — i.e. the rule holds for *all* inputs. Historically the
+//! terms were built directly against Z3's `z3::ast::BV` and discharged with
+//! `z3::Solver`.
+//!
+//! This module is the **migration boundary** for moving that verification off
+//! Z3 and onto `ordeal` — the org's pure-Rust, certificate-checked QF_BV
+//! decision procedure. It introduces:
+//!
+//!   1. A backend-neutral term DSL ([`RuleTerm`] / [`RuleBool`]) that captures
+//!      exactly the QF_BV fragment the rules use (widths 32/64, no arrays, no
+//!      uninterpreted functions).
+//!   2. A [`RuleSolver`] trait: `prove_rule_equiv(lhs, rhs) -> RuleVerdict`.
+//!   3. Two implementations — [`Z3RuleSolver`] (the original Z3 logic) and
+//!      [`OrdealRuleSolver`] (via `ordeal::Solver::prove_equiv`, with a
+//!      defence-in-depth certificate `recheck`).
+//!
+//! The backend is selected by the `LOOM_VERIFY_BACKEND` environment variable:
+//!
+//!   * `z3`     — Z3 only (default; keeps existing behaviour while ordeal
+//!                is burned in).
+//!   * `ordeal` — ordeal only.
+//!   * `both`   — run **both** and assert the verdicts AGREE. This is the
+//!                differential burn-in: it proves ordeal reaches the same
+//!                verdict as Z3 on every rule LOOM already proves. A
+//!                disagreement is a hard error (either a real solver bug or a
+//!                fragment gap to file upstream on ordeal).
+//!
+//! Tier-2 (`verify.rs`, the whole-function translation validator) will grow the
+//! same boundary later; keeping the seam small and explicit here is what makes
+//! that migration tractable.
+
+use std::sync::Arc;
+
+// ============================================================================
+// Backend-neutral term DSL
+// ============================================================================
+
+/// A backend-neutral bitvector term.
+///
+/// This is the closed QF_BV fragment the algebraic rules actually exercise —
+/// deliberately minimal so both the Z3 and the ordeal lowering are total and
+/// obviously faithful. Every variant maps to a single well-defined operation in
+/// each backend.
+#[derive(Clone, Debug)]
+pub enum RuleTerm {
+    /// A concrete bitvector constant of the given width.
+    Const {
+        /// The constant value (low `width` bits are significant).
+        value: u128,
+        /// Bit width.
+        width: u32,
+    },
+    /// A free bitvector variable of the given width.
+    Var {
+        /// Variable name.
+        name: String,
+        /// Bit width.
+        width: u32,
+    },
+
+    // Arithmetic
+    /// Modular addition (`bvadd`).
+    Add(Box<RuleTerm>, Box<RuleTerm>),
+    /// Modular subtraction (`bvsub`).
+    Sub(Box<RuleTerm>, Box<RuleTerm>),
+    /// Modular multiplication (`bvmul`).
+    Mul(Box<RuleTerm>, Box<RuleTerm>),
+    /// Unsigned division (`bvudiv`).
+    Udiv(Box<RuleTerm>, Box<RuleTerm>),
+    /// Unsigned remainder (`bvurem`).
+    Urem(Box<RuleTerm>, Box<RuleTerm>),
+
+    // Bitwise
+    /// Bitwise AND (`bvand`).
+    And(Box<RuleTerm>, Box<RuleTerm>),
+    /// Bitwise OR (`bvor`).
+    Or(Box<RuleTerm>, Box<RuleTerm>),
+    /// Bitwise XOR (`bvxor`).
+    Xor(Box<RuleTerm>, Box<RuleTerm>),
+
+    // Shifts
+    /// Logical shift left (`bvshl`).
+    Shl(Box<RuleTerm>, Box<RuleTerm>),
+    /// Logical shift right (`bvlshr`).
+    Lshr(Box<RuleTerm>, Box<RuleTerm>),
+    /// Arithmetic shift right (`bvashr`).
+    Ashr(Box<RuleTerm>, Box<RuleTerm>),
+
+    // Structural
+    /// Bit extraction `[hi:lo]` (inclusive), yielding a `(hi - lo + 1)`-bit term.
+    Extract {
+        /// High bit index (inclusive).
+        hi: u32,
+        /// Low bit index (inclusive).
+        lo: u32,
+        /// Operand.
+        arg: Box<RuleTerm>,
+    },
+    /// Sign-extension by `by` bits (`sign_ext`).
+    SignExt {
+        /// Number of bits to add.
+        by: u32,
+        /// Operand.
+        arg: Box<RuleTerm>,
+    },
+
+    /// If-then-else: `cond ? then_ : else_` (both arms share the result width).
+    Ite {
+        /// Boolean condition.
+        cond: Box<RuleBool>,
+        /// Value when `cond` holds.
+        then_: Box<RuleTerm>,
+        /// Value when `cond` does not hold.
+        else_: Box<RuleTerm>,
+    },
+}
+
+/// A backend-neutral boolean term (used only as `Ite` conditions in the rules).
+#[derive(Clone, Debug)]
+pub enum RuleBool {
+    /// Bitvector equality (`=`).
+    Eq(Box<RuleTerm>, Box<RuleTerm>),
+    /// Logical negation.
+    Not(Box<RuleBool>),
+}
+
+// --- Ergonomic constructors (mirror the fluent Z3 builder style) ------------
+
+impl RuleTerm {
+    /// A bitvector constant from an unsigned value.
+    pub fn from_u64(value: u64, width: u32) -> Self {
+        RuleTerm::Const {
+            value: value as u128,
+            width,
+        }
+    }
+
+    /// A bitvector constant from a signed value (two's-complement, masked to
+    /// `width`).
+    pub fn from_i64(value: i64, width: u32) -> Self {
+        let mask: u128 = if width >= 128 {
+            u128::MAX
+        } else {
+            (1u128 << width) - 1
+        };
+        RuleTerm::Const {
+            value: (value as u128) & mask,
+            width,
+        }
+    }
+
+    /// A free bitvector variable.
+    pub fn new_const(name: &str, width: u32) -> Self {
+        RuleTerm::Var {
+            name: name.to_string(),
+            width,
+        }
+    }
+
+    /// The bit width of this term.
+    pub fn width(&self) -> u32 {
+        match self {
+            RuleTerm::Const { width, .. } | RuleTerm::Var { width, .. } => *width,
+            RuleTerm::Add(a, _)
+            | RuleTerm::Sub(a, _)
+            | RuleTerm::Mul(a, _)
+            | RuleTerm::Udiv(a, _)
+            | RuleTerm::Urem(a, _)
+            | RuleTerm::And(a, _)
+            | RuleTerm::Or(a, _)
+            | RuleTerm::Xor(a, _)
+            | RuleTerm::Shl(a, _)
+            | RuleTerm::Lshr(a, _)
+            | RuleTerm::Ashr(a, _) => a.width(),
+            RuleTerm::Extract { hi, lo, .. } => hi - lo + 1,
+            RuleTerm::SignExt { by, arg } => arg.width() + by,
+            RuleTerm::Ite { then_, .. } => then_.width(),
+        }
+    }
+
+    /// `self + rhs`
+    pub fn add(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::Add(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// `self - rhs`
+    pub fn sub(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::Sub(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// `self * rhs`
+    pub fn mul(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::Mul(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// `self /u rhs`
+    pub fn udiv(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::Udiv(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// `self %u rhs`
+    pub fn urem(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::Urem(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// `self & rhs`
+    pub fn and(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::And(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// `self | rhs`
+    pub fn or(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::Or(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// `self ^ rhs`
+    pub fn xor(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::Xor(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// `self << rhs`
+    pub fn shl(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::Shl(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// `self >>u rhs`
+    pub fn lshr(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::Lshr(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// `self >>s rhs`
+    pub fn ashr(&self, rhs: &RuleTerm) -> RuleTerm {
+        RuleTerm::Ashr(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+    /// Sign-extend by `by` bits.
+    pub fn sign_ext(&self, by: u32) -> RuleTerm {
+        RuleTerm::SignExt {
+            by,
+            arg: Box::new(self.clone()),
+        }
+    }
+    /// Extract bits `[hi:lo]`.
+    pub fn extract(&self, hi: u32, lo: u32) -> RuleTerm {
+        RuleTerm::Extract {
+            hi,
+            lo,
+            arg: Box::new(self.clone()),
+        }
+    }
+    /// Equality condition `self == rhs`.
+    pub fn eq_bool(&self, rhs: &RuleTerm) -> RuleBool {
+        RuleBool::Eq(Box::new(self.clone()), Box::new(rhs.clone()))
+    }
+}
+
+impl RuleBool {
+    /// Negate this boolean condition.
+    pub fn not(&self) -> RuleBool {
+        RuleBool::Not(Box::new(self.clone()))
+    }
+    /// Build `cond ? then_ : else_`.
+    pub fn ite(&self, then_: &RuleTerm, else_: &RuleTerm) -> RuleTerm {
+        RuleTerm::Ite {
+            cond: Box::new(self.clone()),
+            then_: Box::new(then_.clone()),
+            else_: Box::new(else_.clone()),
+        }
+    }
+}
+
+// ============================================================================
+// Solver trait + verdict
+// ============================================================================
+
+/// The verdict of proving a rule (`lhs == rhs` for all inputs).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuleVerdict {
+    /// Proven: `lhs == rhs` holds for all inputs (the negation is `Unsat`).
+    Proven,
+    /// Disproven: a counterexample exists. The string is a human-readable
+    /// rendering of the model.
+    Disproven(String),
+    /// The solver could not decide (or the query was ill-formed). Treated
+    /// conservatively — never as a proof.
+    Unknown,
+}
+
+impl RuleVerdict {
+    /// Whether this verdict is [`RuleVerdict::Proven`].
+    pub fn is_proven(&self) -> bool {
+        matches!(self, RuleVerdict::Proven)
+    }
+
+    /// The counterexample string, if disproven.
+    pub fn counterexample(&self) -> Option<&str> {
+        match self {
+            RuleVerdict::Disproven(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Whether two verdicts agree for the purposes of the `both`-mode
+    /// differential. Proven==Proven and Unknown==Unknown must match exactly;
+    /// two `Disproven` verdicts agree even if the counterexample text differs
+    /// (different solvers legitimately pick different witnesses).
+    fn agrees_with(&self, other: &RuleVerdict) -> bool {
+        matches!(
+            (self, other),
+            (RuleVerdict::Proven, RuleVerdict::Proven)
+                | (RuleVerdict::Disproven(_), RuleVerdict::Disproven(_))
+                | (RuleVerdict::Unknown, RuleVerdict::Unknown)
+        )
+    }
+}
+
+/// A swappable rule-verification backend.
+///
+/// The single obligation `prove_rule_equiv(lhs, rhs)` asks: does `lhs == rhs`
+/// hold for *all* assignments to the free variables? Implementations assert the
+/// negation and map the solver result onto [`RuleVerdict`].
+pub trait RuleSolver {
+    /// Prove `lhs == rhs` for all inputs.
+    fn prove_rule_equiv(&self, lhs: &RuleTerm, rhs: &RuleTerm) -> RuleVerdict;
+
+    /// A short human-readable backend name (for diagnostics).
+    fn backend_name(&self) -> &'static str;
+}
+
+// ============================================================================
+// Backend selection
+// ============================================================================
+
+/// Which backend(s) the rule verifier should use, from `LOOM_VERIFY_BACKEND`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifyBackend {
+    /// Z3 only (default).
+    Z3,
+    /// ordeal only.
+    Ordeal,
+    /// Both, asserting the verdicts agree (the differential burn-in).
+    Both,
+}
+
+impl VerifyBackend {
+    /// Read the backend from `LOOM_VERIFY_BACKEND` (default: [`VerifyBackend::Z3`]).
+    ///
+    /// Unrecognized values fall back to the default with no panic — the
+    /// verifier must never be *harder* to run than before.
+    pub fn from_env() -> Self {
+        match std::env::var("LOOM_VERIFY_BACKEND")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("ordeal") => VerifyBackend::Ordeal,
+            Some("both") => VerifyBackend::Both,
+            _ => VerifyBackend::Z3,
+        }
+    }
+}
+
+/// Resolve the active [`RuleSolver`] from the environment.
+///
+/// In `both` mode the returned solver runs Z3 and ordeal and asserts they
+/// agree on every query.
+pub fn active_solver() -> Arc<dyn RuleSolver + Send + Sync> {
+    match VerifyBackend::from_env() {
+        VerifyBackend::Z3 => Arc::new(Z3RuleSolver),
+        VerifyBackend::Ordeal => Arc::new(OrdealRuleSolver),
+        VerifyBackend::Both => Arc::new(DifferentialRuleSolver),
+    }
+}
+
+// ============================================================================
+// Z3 backend (the original logic, now behind the trait)
+// ============================================================================
+
+/// The Z3-backed rule solver — the historical verification path.
+pub struct Z3RuleSolver;
+
+#[cfg(feature = "verification")]
+mod z3_backend {
+    use super::{RuleBool, RuleSolver, RuleTerm, RuleVerdict, Z3RuleSolver};
+    use z3::ast::{BV, Bool};
+    use z3::{SatResult, Solver};
+
+    fn lower(term: &RuleTerm) -> BV {
+        match term {
+            RuleTerm::Const { value, width } => {
+                // Widths in the rule fragment are <= 128; the low `width` bits
+                // carry the value. `from_u64` covers everything the rules use
+                // (all constants fit in 64 bits); wider constants would need a
+                // string path, but the fragment never builds them.
+                BV::from_u64(*value as u64, *width)
+            }
+            RuleTerm::Var { name, width } => BV::new_const(name.as_str(), *width),
+            RuleTerm::Add(a, b) => lower(a).bvadd(&lower(b)),
+            RuleTerm::Sub(a, b) => lower(a).bvsub(&lower(b)),
+            RuleTerm::Mul(a, b) => lower(a).bvmul(&lower(b)),
+            RuleTerm::Udiv(a, b) => lower(a).bvudiv(&lower(b)),
+            RuleTerm::Urem(a, b) => lower(a).bvurem(&lower(b)),
+            RuleTerm::And(a, b) => lower(a).bvand(&lower(b)),
+            RuleTerm::Or(a, b) => lower(a).bvor(&lower(b)),
+            RuleTerm::Xor(a, b) => lower(a).bvxor(&lower(b)),
+            RuleTerm::Shl(a, b) => lower(a).bvshl(&lower(b)),
+            RuleTerm::Lshr(a, b) => lower(a).bvlshr(&lower(b)),
+            RuleTerm::Ashr(a, b) => lower(a).bvashr(&lower(b)),
+            RuleTerm::Extract { hi, lo, arg } => lower(arg).extract(*hi, *lo),
+            RuleTerm::SignExt { by, arg } => lower(arg).sign_ext(*by),
+            RuleTerm::Ite { cond, then_, else_ } => {
+                lower_bool(cond).ite(&lower(then_), &lower(else_))
+            }
+        }
+    }
+
+    fn lower_bool(cond: &RuleBool) -> Bool {
+        match cond {
+            RuleBool::Eq(a, b) => lower(a).eq(&lower(b)),
+            RuleBool::Not(inner) => lower_bool(inner).not(),
+        }
+    }
+
+    impl RuleSolver for Z3RuleSolver {
+        fn prove_rule_equiv(&self, lhs: &RuleTerm, rhs: &RuleTerm) -> RuleVerdict {
+            let solver = Solver::new();
+            let l = lower(lhs);
+            let r = lower(rhs);
+            // Look for a counterexample: assert lhs != rhs.
+            solver.assert(&l.eq(&r).not());
+            match solver.check() {
+                SatResult::Unsat => RuleVerdict::Proven,
+                SatResult::Sat => {
+                    let model = solver.get_model().unwrap();
+                    RuleVerdict::Disproven(format!("{}", model))
+                }
+                SatResult::Unknown => RuleVerdict::Unknown,
+            }
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "z3"
+        }
+    }
+}
+
+/// When verification is disabled, the Z3 backend is unavailable and always
+/// reports `Unknown` (conservative — never a proof).
+#[cfg(not(feature = "verification"))]
+impl RuleSolver for Z3RuleSolver {
+    fn prove_rule_equiv(&self, _lhs: &RuleTerm, _rhs: &RuleTerm) -> RuleVerdict {
+        RuleVerdict::Unknown
+    }
+    fn backend_name(&self) -> &'static str {
+        "z3(disabled)"
+    }
+}
+
+// ============================================================================
+// ordeal backend (certificate-checked QF_BV)
+// ============================================================================
+
+/// The ordeal-backed rule solver — pure-Rust, certificate-checked QF_BV.
+pub struct OrdealRuleSolver;
+
+#[cfg(feature = "verification")]
+mod ordeal_backend {
+    use super::{OrdealRuleSolver, RuleBool, RuleSolver, RuleTerm, RuleVerdict};
+    use ordeal::lowering;
+    use ordeal::{BoolTerm, BvTerm, CheckResult, Solver, Sort};
+
+    fn lower(term: &RuleTerm) -> BvTerm {
+        match term {
+            RuleTerm::Const { value, width } => BvTerm::Const {
+                value: *value,
+                sort: Sort::new(*width),
+            },
+            RuleTerm::Var { name, width } => BvTerm::Var {
+                name: name.clone(),
+                sort: Sort::new(*width),
+            },
+            RuleTerm::Add(a, b) => BvTerm::Add(Box::new(lower(a)), Box::new(lower(b))),
+            RuleTerm::Sub(a, b) => BvTerm::Sub(Box::new(lower(a)), Box::new(lower(b))),
+            RuleTerm::Mul(a, b) => BvTerm::Mul(Box::new(lower(a)), Box::new(lower(b))),
+            RuleTerm::Udiv(a, b) => BvTerm::Udiv(Box::new(lower(a)), Box::new(lower(b))),
+            // bvurem is a blessed derived op in ordeal::lowering.
+            RuleTerm::Urem(a, b) => lowering::bvurem(lower(a), lower(b), a.width()),
+            RuleTerm::And(a, b) => BvTerm::And(Box::new(lower(a)), Box::new(lower(b))),
+            RuleTerm::Or(a, b) => BvTerm::Or(Box::new(lower(a)), Box::new(lower(b))),
+            RuleTerm::Xor(a, b) => BvTerm::Xor(Box::new(lower(a)), Box::new(lower(b))),
+            RuleTerm::Shl(a, b) => BvTerm::Shl(Box::new(lower(a)), Box::new(lower(b))),
+            RuleTerm::Lshr(a, b) => BvTerm::Lshr(Box::new(lower(a)), Box::new(lower(b))),
+            RuleTerm::Ashr(a, b) => BvTerm::Ashr(Box::new(lower(a)), Box::new(lower(b))),
+            RuleTerm::Extract { hi, lo, arg } => BvTerm::Extract {
+                hi: *hi,
+                lo: *lo,
+                arg: Box::new(lower(arg)),
+            },
+            RuleTerm::SignExt { by, arg } => BvTerm::SignExt {
+                by: *by,
+                arg: Box::new(lower(arg)),
+            },
+            RuleTerm::Ite { cond, then_, else_ } => BvTerm::Ite {
+                cond: Box::new(lower_bool(cond)),
+                then_: Box::new(lower(then_)),
+                else_: Box::new(lower(else_)),
+            },
+        }
+    }
+
+    fn lower_bool(cond: &RuleBool) -> BoolTerm {
+        match cond {
+            RuleBool::Eq(a, b) => BoolTerm::Eq(Box::new(lower(a)), Box::new(lower(b))),
+            RuleBool::Not(inner) => BoolTerm::Not(Box::new(lower_bool(inner))),
+        }
+    }
+
+    fn render_model(m: &ordeal::Model) -> String {
+        if m.assignments.is_empty() {
+            return "(no free variables)".to_string();
+        }
+        m.assignments
+            .iter()
+            .map(|(name, value)| format!("{} -> {:#x}", name, value))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    impl RuleSolver for OrdealRuleSolver {
+        fn prove_rule_equiv(&self, lhs: &RuleTerm, rhs: &RuleTerm) -> RuleVerdict {
+            let l = lower(lhs);
+            let r = lower(rhs);
+            // prove_equiv asserts the negation (lhs != rhs) and runs the
+            // certificate-checked pipeline.
+            match Solver::prove_equiv(l, r) {
+                CheckResult::Unsat(cert) => {
+                    // Defence in depth: re-validate the LRAT certificate. A
+                    // rejection here would mean an ordeal bug (a certificate
+                    // that the checker itself won't accept) — treat it as
+                    // "not proven" rather than silently trusting.
+                    match cert.recheck() {
+                        Ok(()) => RuleVerdict::Proven,
+                        Err(_) => RuleVerdict::Unknown,
+                    }
+                }
+                CheckResult::Sat(model) => RuleVerdict::Disproven(render_model(&model)),
+                CheckResult::Unknown => RuleVerdict::Unknown,
+            }
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "ordeal"
+        }
+    }
+}
+
+/// When verification is disabled, ordeal is unavailable and always reports
+/// `Unknown` (conservative — never a proof).
+#[cfg(not(feature = "verification"))]
+impl RuleSolver for OrdealRuleSolver {
+    fn prove_rule_equiv(&self, _lhs: &RuleTerm, _rhs: &RuleTerm) -> RuleVerdict {
+        RuleVerdict::Unknown
+    }
+    fn backend_name(&self) -> &'static str {
+        "ordeal(disabled)"
+    }
+}
+
+// ============================================================================
+// Differential backend (`both`) — the burn-in
+// ============================================================================
+
+/// Runs Z3 and ordeal on every query and asserts they AGREE.
+///
+/// This is how a solver migration is de-risked: for every rule LOOM already
+/// proves via Z3, ordeal must reach the same verdict. A disagreement panics —
+/// it is either a real solver bug or a fragment gap, and must be investigated
+/// (and, if it is an ordeal gap, filed upstream) rather than silently absorbed.
+pub struct DifferentialRuleSolver;
+
+impl RuleSolver for DifferentialRuleSolver {
+    fn prove_rule_equiv(&self, lhs: &RuleTerm, rhs: &RuleTerm) -> RuleVerdict {
+        let z3 = Z3RuleSolver.prove_rule_equiv(lhs, rhs);
+        let ordeal = OrdealRuleSolver.prove_rule_equiv(lhs, rhs);
+        assert!(
+            z3.agrees_with(&ordeal),
+            "LOOM_VERIFY_BACKEND=both: solver disagreement!\n  z3     = {:?}\n  ordeal = {:?}\n  lhs    = {:?}\n  rhs    = {:?}",
+            z3,
+            ordeal,
+            lhs,
+            rhs
+        );
+        // Verdicts agree; return the Z3 verdict (they are equivalent for the
+        // caller's purposes, and Z3's counterexample string is the historical
+        // format the rest of the pipeline already parses).
+        z3
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "both(z3+ordeal)"
+    }
+}
+
+#[cfg(all(test, feature = "verification"))]
+mod tests {
+    use super::*;
+
+    fn all_backends() -> Vec<Box<dyn RuleSolver>> {
+        vec![
+            Box::new(Z3RuleSolver),
+            Box::new(OrdealRuleSolver),
+            Box::new(DifferentialRuleSolver),
+        ]
+    }
+
+    #[test]
+    fn proves_add_zero_identity_i32() {
+        let x = RuleTerm::new_const("x", 32);
+        let zero = RuleTerm::from_u64(0, 32);
+        let lhs = x.add(&zero);
+        for s in all_backends() {
+            assert_eq!(
+                s.prove_rule_equiv(&lhs, &x),
+                RuleVerdict::Proven,
+                "{}: x + 0 == x should be proven",
+                s.backend_name()
+            );
+        }
+    }
+
+    #[test]
+    fn proves_mul_pow2_is_shift_i32() {
+        let x = RuleTerm::new_const("x", 32);
+        let lhs = x.mul(&RuleTerm::from_u64(8, 32));
+        let rhs = x.shl(&RuleTerm::from_u64(3, 32));
+        for s in all_backends() {
+            assert_eq!(
+                s.prove_rule_equiv(&lhs, &rhs),
+                RuleVerdict::Proven,
+                "{}: x * 8 == x << 3 should be proven",
+                s.backend_name()
+            );
+        }
+    }
+
+    #[test]
+    fn disproves_false_rule() {
+        // x + 1 == x is false; both solvers must find a counterexample.
+        let x = RuleTerm::new_const("x", 32);
+        let lhs = x.add(&RuleTerm::from_u64(1, 32));
+        for s in [
+            Box::new(Z3RuleSolver) as Box<dyn RuleSolver>,
+            Box::new(OrdealRuleSolver),
+        ] {
+            let v = s.prove_rule_equiv(&lhs, &x);
+            assert!(
+                v.counterexample().is_some(),
+                "{}: x + 1 == x should be disproven, got {:?}",
+                s.backend_name(),
+                v
+            );
+        }
+    }
+
+    #[test]
+    fn urem_pow2_is_mask_ordeal_and_z3() {
+        // x %u 8 == x & 7
+        let x = RuleTerm::new_const("x", 32);
+        let lhs = x.urem(&RuleTerm::from_u64(8, 32));
+        let rhs = x.and(&RuleTerm::from_u64(7, 32));
+        assert_eq!(
+            DifferentialRuleSolver.prove_rule_equiv(&lhs, &rhs),
+            RuleVerdict::Proven
+        );
+    }
+}

--- a/loom-core/src/verify_rules.rs
+++ b/loom-core/src/verify_rules.rs
@@ -2,26 +2,33 @@
 #![allow(clippy::needless_borrows_for_generic_args)]
 #![allow(clippy::unnecessary_cast)]
 
-//! Z3-Based Optimization Rule Verification
+//! Optimization Rule Verification (swappable SMT backend)
 //!
-//! This module provides formal verification for LOOM's optimization rules using Z3.
-//! Each optimization rule gets a corresponding SMT proof that demonstrates correctness
-//! for ALL possible inputs, providing stronger guarantees than even years of fuzzing.
+//! This module provides formal verification for LOOM's optimization rules.
+//! Each optimization rule gets a corresponding SMT proof that demonstrates
+//! correctness for ALL possible inputs, providing stronger guarantees than even
+//! years of fuzzing.
+//!
+//! Proofs are discharged through the [`crate::rule_solver`] boundary, which can
+//! run Z3, the pure-Rust certificate-checked `ordeal` solver, or both in a
+//! differential burn-in — selected by `LOOM_VERIFY_BACKEND` (issue #277). This
+//! module only builds the backend-neutral proof obligations; the choice of
+//! decision procedure lives in `rule_solver`.
 //!
 //! # Philosophy
 //!
-//! Binaryen has ~8 years of accumulated tests and fuzzing infrastructure. However,
-//! testing can only check specific inputs. Z3 proofs cover ALL inputs simultaneously:
+//! Testing can only check specific inputs. SMT proofs cover ALL inputs
+//! simultaneously:
 //!
 //! - A test `assert_eq!(42 * 2, 42 << 1)` checks ONE case
-//! - A Z3 proof `∀x: i32. x * 2 = x << 1` covers 2^32 cases INSTANTLY
+//! - A proof `∀x: i32. x * 2 = x << 1` covers 2^32 cases INSTANTLY
 //!
 //! # Architecture
 //!
 //! 1. **Rule Specifications**: Each optimization rule has an SMT specification
 //! 2. **Proof Obligations**: Rules generate proof obligations (theorems)
-//! 3. **Z3 Verification**: Obligations are discharged using Z3
-//! 4. **Counterexample Generation**: If invalid, Z3 produces counterexamples
+//! 3. **Verification**: Obligations are discharged via the active backend
+//! 4. **Counterexample Generation**: If invalid, a counterexample is produced
 //!
 //! # Example
 //!
@@ -31,14 +38,72 @@
 //! assert!(proof.is_proven());
 //! ```
 
+// Rule proofs are discharged through the swappable solver boundary
+// (`rule_solver`): terms are built in the backend-neutral `RuleTerm` DSL and
+// proven via the backend selected by `LOOM_VERIFY_BACKEND` (z3 / ordeal / both).
+// See `rule_solver.rs` for the migration rationale (issue #277).
 #[cfg(feature = "verification")]
-use z3::ast::BV;
-#[cfg(feature = "verification")]
-use z3::{SatResult, Solver};
+use crate::rule_solver::{RuleTerm, RuleVerdict, active_solver};
 
 #[allow(unused_imports)]
 use anyhow::{Result, anyhow};
 use std::collections::HashMap;
+
+/// Shorthand for a 32-bit bitvector constant in the rule DSL.
+#[cfg(feature = "verification")]
+fn bv_u(value: u64, width: u32) -> RuleTerm {
+    RuleTerm::from_u64(value, width)
+}
+
+/// Shorthand for a signed bitvector constant in the rule DSL.
+#[cfg(feature = "verification")]
+fn bv_i(value: i64, width: u32) -> RuleTerm {
+    RuleTerm::from_i64(value, width)
+}
+
+/// Discharge a rule proof obligation `lhs == rhs` (for all inputs) through the
+/// active solver backend, converting the verdict into a [`RuleProof`].
+#[cfg(feature = "verification")]
+fn prove_rule(rule_name: &str, lhs: &RuleTerm, rhs: &RuleTerm, details: &str) -> RuleProof {
+    let start = std::time::Instant::now();
+    let verdict = active_solver().prove_rule_equiv(lhs, rhs);
+    let time_ms = start.elapsed().as_millis() as u64;
+    match verdict {
+        RuleVerdict::Proven => RuleProof::proven(rule_name, time_ms, details),
+        RuleVerdict::Disproven(ce) => RuleProof::disproven(rule_name, ce, time_ms),
+        RuleVerdict::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
+    }
+}
+
+/// Discharge a NEGATIVE proof obligation: prove that `lhs == rhs` does NOT hold
+/// for all inputs (i.e. a counterexample exists). Used to demonstrate that an
+/// unsound optimization is genuinely unsound.
+#[cfg(feature = "verification")]
+fn prove_rule_not_equiv(
+    rule_name: &str,
+    lhs: &RuleTerm,
+    rhs: &RuleTerm,
+    details: &str,
+) -> RuleProof {
+    let start = std::time::Instant::now();
+    let verdict = active_solver().prove_rule_equiv(lhs, rhs);
+    let time_ms = start.elapsed().as_millis() as u64;
+    match verdict {
+        // A counterexample means the equivalence fails — which is exactly what
+        // this negative proof is asserting, so the NEGATIVE proof is PROVEN.
+        RuleVerdict::Disproven(ce) => RuleProof::proven(
+            rule_name,
+            time_ms,
+            &format!("{} (counterexample: {}) ✓", details, ce),
+        ),
+        RuleVerdict::Proven => RuleProof::disproven(
+            rule_name,
+            "unexpectedly no counterexample found".to_string(),
+            time_ms,
+        ),
+        RuleVerdict::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
+    }
+}
 
 // ============================================================================
 // Optimization Rule Specification Framework
@@ -159,45 +224,17 @@ impl VerifiedRuleSet {
 /// The proof covers ALL 2^32 possible values of x simultaneously.
 #[cfg(feature = "verification")]
 pub fn verify_strength_reduction_mul_power2_i32(power: u32) -> RuleProof {
-    let start = std::time::Instant::now();
     let rule_name = format!("strength_reduction_mul_pow2_i32({})", 1u32 << power);
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    // Create symbolic variable x
-    let x = BV::new_const("x", 32);
-
-    // Left side: x * (2^power)
-    let multiplier = BV::from_u64((1u64 << power) as u64, 32);
-    let mul_result = x.bvmul(&multiplier);
-
-    // Right side: x << power
-    let shift_amt = BV::from_u64(power as u64, 32);
-    let shift_result = x.bvshl(&shift_amt);
-
-    // Assert they are NOT equal (looking for counterexample)
-    solver.assert(&mul_result.eq(&shift_result).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => {
-            // No counterexample exists - rule is PROVEN correct
-            RuleProof::proven(
-                &rule_name,
-                time_ms,
-                &format!("∀x: i32. x * {} = x << {} ✓", 1u32 << power, power),
-            )
-        }
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            let ce = format!("{}", model);
-            RuleProof::disproven(&rule_name, ce, time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(&rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    // Left side: x * (2^power); Right side: x << power
+    let lhs = x.mul(&bv_u(1u64 << power, 32));
+    let rhs = x.shl(&bv_u(power as u64, 32));
+    prove_rule(
+        &rule_name,
+        &lhs,
+        &rhs,
+        &format!("∀x: i32. x * {} = x << {} ✓", 1u32 << power, power),
+    )
 }
 
 /// Verify: x / (2^n) == x >> n for unsigned i32
@@ -205,39 +242,17 @@ pub fn verify_strength_reduction_mul_power2_i32(power: u32) -> RuleProof {
 /// Note: This is only valid for UNSIGNED division. Signed division has different semantics.
 #[cfg(feature = "verification")]
 pub fn verify_strength_reduction_div_power2_u32(power: u32) -> RuleProof {
-    let start = std::time::Instant::now();
     let rule_name = format!("strength_reduction_div_pow2_u32({})", 1u32 << power);
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-
-    // Left side: x /u (2^power)
-    let divisor = BV::from_u64((1u64 << power) as u64, 32);
-    let div_result = x.bvudiv(&divisor);
-
-    // Right side: x >>u power
-    let shift_amt = BV::from_u64(power as u64, 32);
-    let shift_result = x.bvlshr(&shift_amt);
-
-    solver.assert(&div_result.eq(&shift_result).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(
-            &rule_name,
-            time_ms,
-            &format!("∀x: u32. x /u {} = x >>u {} ✓", 1u32 << power, power),
-        ),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(&rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(&rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    // Left side: x /u (2^power); Right side: x >>u power
+    let lhs = x.udiv(&bv_u(1u64 << power, 32));
+    let rhs = x.lshr(&bv_u(power as u64, 32));
+    prove_rule(
+        &rule_name,
+        &lhs,
+        &rhs,
+        &format!("∀x: u32. x /u {} = x >>u {} ✓", 1u32 << power, power),
+    )
 }
 
 /// Verify: x % (2^n) == x & (2^n - 1) for unsigned i32
@@ -245,41 +260,19 @@ pub fn verify_strength_reduction_div_power2_u32(power: u32) -> RuleProof {
 /// Modulo by power of 2 can be replaced by AND with mask.
 #[cfg(feature = "verification")]
 pub fn verify_strength_reduction_rem_power2_u32(power: u32) -> RuleProof {
-    let start = std::time::Instant::now();
     let divisor = 1u32 << power;
     let mask = divisor - 1;
     let rule_name = format!("strength_reduction_rem_pow2_u32({})", divisor);
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-
-    // Left side: x %u (2^power)
-    let divisor_bv = BV::from_u64(divisor as u64, 32);
-    let rem_result = x.bvurem(&divisor_bv);
-
-    // Right side: x & (2^power - 1)
-    let mask_bv = BV::from_u64(mask as u64, 32);
-    let and_result = x.bvand(&mask_bv);
-
-    solver.assert(&rem_result.eq(&and_result).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(
-            &rule_name,
-            time_ms,
-            &format!("∀x: u32. x %u {} = x & {} ✓", divisor, mask),
-        ),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(&rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(&rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    // Left side: x %u (2^power); Right side: x & (2^power - 1)
+    let lhs = x.urem(&bv_u(divisor as u64, 32));
+    let rhs = x.and(&bv_u(mask as u64, 32));
+    prove_rule(
+        &rule_name,
+        &lhs,
+        &rhs,
+        &format!("∀x: u32. x %u {} = x & {} ✓", divisor, mask),
+    )
 }
 
 // ============================================================================
@@ -289,117 +282,34 @@ pub fn verify_strength_reduction_rem_power2_u32(power: u32) -> RuleProof {
 /// Verify: x + 0 == x (additive identity)
 #[cfg(feature = "verification")]
 pub fn verify_add_zero_identity_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "add_zero_identity_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let zero = BV::from_u64(0, 32);
-
-    let add_result = x.bvadd(&zero);
-
-    solver.assert(&add_result.eq(&x).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. x + 0 = x ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let lhs = x.add(&bv_u(0, 32));
+    prove_rule("add_zero_identity_i32", &lhs, &x, "∀x: i32. x + 0 = x ✓")
 }
 
 /// Verify: x * 0 == 0 (multiplicative annihilator)
 #[cfg(feature = "verification")]
 pub fn verify_mul_zero_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "mul_zero_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let zero = BV::from_u64(0, 32);
-
-    let mul_result = x.bvmul(&zero);
-
-    solver.assert(&mul_result.eq(&zero).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. x * 0 = 0 ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let zero = bv_u(0, 32);
+    let lhs = x.mul(&zero);
+    prove_rule("mul_zero_i32", &lhs, &zero, "∀x: i32. x * 0 = 0 ✓")
 }
 
 /// Verify: x * 1 == x (multiplicative identity)
 #[cfg(feature = "verification")]
 pub fn verify_mul_one_identity_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "mul_one_identity_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let one = BV::from_u64(1, 32);
-
-    let mul_result = x.bvmul(&one);
-
-    solver.assert(&mul_result.eq(&x).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. x * 1 = x ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let lhs = x.mul(&bv_u(1, 32));
+    prove_rule("mul_one_identity_i32", &lhs, &x, "∀x: i32. x * 1 = x ✓")
 }
 
 /// Verify: x - x == 0 (self-subtraction)
 #[cfg(feature = "verification")]
 pub fn verify_sub_self_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "sub_self_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let zero = BV::from_u64(0, 32);
-
-    let sub_result = x.bvsub(&x);
-
-    solver.assert(&sub_result.eq(&zero).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. x - x = 0 ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let lhs = x.sub(&x);
+    prove_rule("sub_self_i32", &lhs, &bv_u(0, 32), "∀x: i32. x - x = 0 ✓")
 }
 
 // ============================================================================
@@ -409,177 +319,56 @@ pub fn verify_sub_self_i32() -> RuleProof {
 /// Verify: x XOR x == 0
 #[cfg(feature = "verification")]
 pub fn verify_xor_self_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "xor_self_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let zero = BV::from_u64(0, 32);
-
-    let xor_result = x.bvxor(&x);
-
-    solver.assert(&xor_result.eq(&zero).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. x XOR x = 0 ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let lhs = x.xor(&x);
+    prove_rule("xor_self_i32", &lhs, &bv_u(0, 32), "∀x: i32. x XOR x = 0 ✓")
 }
 
 /// Verify: x AND x == x (idempotent)
 #[cfg(feature = "verification")]
 pub fn verify_and_self_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "and_self_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-
-    let and_result = x.bvand(&x);
-
-    solver.assert(&and_result.eq(&x).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. x AND x = x ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let lhs = x.and(&x);
+    prove_rule("and_self_i32", &lhs, &x, "∀x: i32. x AND x = x ✓")
 }
 
 /// Verify: x OR x == x (idempotent)
 #[cfg(feature = "verification")]
 pub fn verify_or_self_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "or_self_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-
-    let or_result = x.bvor(&x);
-
-    solver.assert(&or_result.eq(&x).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. x OR x = x ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let lhs = x.or(&x);
+    prove_rule("or_self_i32", &lhs, &x, "∀x: i32. x OR x = x ✓")
 }
 
 /// Verify: x AND 0 == 0
 #[cfg(feature = "verification")]
 pub fn verify_and_zero_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "and_zero_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let zero = BV::from_u64(0, 32);
-
-    let and_result = x.bvand(&zero);
-
-    solver.assert(&and_result.eq(&zero).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. x AND 0 = 0 ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let zero = bv_u(0, 32);
+    let lhs = x.and(&zero);
+    prove_rule("and_zero_i32", &lhs, &zero, "∀x: i32. x AND 0 = 0 ✓")
 }
 
 /// Verify: x OR (-1) == -1 (all bits set)
 #[cfg(feature = "verification")]
 pub fn verify_or_all_ones_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "or_all_ones_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let all_ones = BV::from_i64(-1, 32); // 0xFFFFFFFF
-
-    let or_result = x.bvor(&all_ones);
-
-    solver.assert(&or_result.eq(&all_ones).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(
-            rule_name,
-            time_ms,
-            "∀x: i32. x OR 0xFFFFFFFF = 0xFFFFFFFF ✓",
-        ),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let all_ones = bv_i(-1, 32); // 0xFFFFFFFF
+    let lhs = x.or(&all_ones);
+    prove_rule(
+        "or_all_ones_i32",
+        &lhs,
+        &all_ones,
+        "∀x: i32. x OR 0xFFFFFFFF = 0xFFFFFFFF ✓",
+    )
 }
 
 /// Verify: x XOR 0 == x (XOR with zero is identity)
 #[cfg(feature = "verification")]
 pub fn verify_xor_zero_identity_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "xor_zero_identity_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let zero = BV::from_u64(0, 32);
-
-    let xor_result = x.bvxor(&zero);
-
-    solver.assert(&xor_result.eq(&x).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. x XOR 0 = x ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let lhs = x.xor(&bv_u(0, 32));
+    prove_rule("xor_zero_identity_i32", &lhs, &x, "∀x: i32. x XOR 0 = x ✓")
 }
 
 // ============================================================================
@@ -589,62 +378,22 @@ pub fn verify_xor_zero_identity_i32() -> RuleProof {
 /// Verify: x == x is always true (returns 1)
 #[cfg(feature = "verification")]
 pub fn verify_eq_self_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "eq_self_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let one = BV::from_u64(1, 32);
-
+    let x = RuleTerm::new_const("x", 32);
+    let one = bv_u(1, 32);
     // (x == x) ? 1 : 0 should always be 1
-    let eq_result = x.eq(&x).ite(&one, &BV::from_u64(0, 32));
-
-    solver.assert(&eq_result.eq(&one).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. (x == x) = 1 ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let lhs = x.eq_bool(&x).ite(&one, &bv_u(0, 32));
+    prove_rule("eq_self_i32", &lhs, &one, "∀x: i32. (x == x) = 1 ✓")
 }
 
 /// Verify: x != x is always false (returns 0)
 #[cfg(feature = "verification")]
 pub fn verify_ne_self_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "ne_self_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let zero = BV::from_u64(0, 32);
-    let one = BV::from_u64(1, 32);
-
+    let x = RuleTerm::new_const("x", 32);
+    let zero = bv_u(0, 32);
+    let one = bv_u(1, 32);
     // (x != x) ? 1 : 0 should always be 0
-    let ne_result = x.eq(&x).not().ite(&one, &zero);
-
-    solver.assert(&ne_result.eq(&zero).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i32. (x != x) = 0 ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let lhs = x.eq_bool(&x).not().ite(&one, &zero);
+    prove_rule("ne_self_i32", &lhs, &zero, "∀x: i32. (x != x) = 0 ✓")
 }
 
 // ============================================================================
@@ -655,37 +404,17 @@ pub fn verify_ne_self_i32() -> RuleProof {
 /// This proves: eval(i32.add(i32.const(a), i32.const(b))) == eval(i32.const(a +_wrap b))
 #[cfg(feature = "verification")]
 pub fn verify_constant_folding_add_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "constant_folding_add_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
     // For any two constants a, b, adding them at runtime equals the pre-computed sum
-    let a = BV::new_const("a", 32);
-    let b = BV::new_const("b", 32);
-
-    let runtime_add = a.bvadd(&b);
-    // The pre-computed result would be the same operation - this is trivially true
-    // but demonstrates the framework
-
-    solver.assert(&runtime_add.eq(&a.bvadd(&b)).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(
-            rule_name,
-            time_ms,
-            "∀a,b: i32. i32.add(a, b) = a +_wrap b ✓",
-        ),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let a = RuleTerm::new_const("a", 32);
+    let b = RuleTerm::new_const("b", 32);
+    let lhs = a.add(&b);
+    let rhs = a.add(&b);
+    prove_rule(
+        "constant_folding_add_i32",
+        &lhs,
+        &rhs,
+        "∀a,b: i32. i32.add(a, b) = a +_wrap b ✓",
+    )
 }
 
 // ============================================================================
@@ -696,36 +425,17 @@ pub fn verify_constant_folding_add_i32() -> RuleProof {
 /// This is a meta-proof that our verification uses the correct semantics
 #[cfg(feature = "verification")]
 pub fn verify_wrapping_add_semantics_i32() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "wrapping_add_semantics_i32";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
     // Test case: i32::MAX + 1 should wrap to i32::MIN
-    let max_val = BV::from_i64(i32::MAX as i64, 32);
-    let one = BV::from_u64(1, 32);
-    let min_val = BV::from_i64(i32::MIN as i64, 32);
-
-    let wrapped_result = max_val.bvadd(&one);
-
-    solver.assert(&wrapped_result.eq(&min_val).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(
-            rule_name,
-            time_ms,
-            "i32::MAX + 1 = i32::MIN (wrapping semantics verified) ✓",
-        ),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let max_val = bv_i(i32::MAX as i64, 32);
+    let one = bv_u(1, 32);
+    let min_val = bv_i(i32::MIN as i64, 32);
+    let lhs = max_val.add(&one);
+    prove_rule(
+        "wrapping_add_semantics_i32",
+        &lhs,
+        &min_val,
+        "i32::MAX + 1 = i32::MIN (wrapping semantics verified) ✓",
+    )
 }
 
 // ============================================================================
@@ -735,66 +445,24 @@ pub fn verify_wrapping_add_semantics_i32() -> RuleProof {
 /// Verify: x + 0 == x for i64
 #[cfg(feature = "verification")]
 pub fn verify_add_zero_identity_i64() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "add_zero_identity_i64";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 64);
-    let zero = BV::from_u64(0, 64);
-
-    let add_result = x.bvadd(&zero);
-
-    solver.assert(&add_result.eq(&x).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x: i64. x + 0 = x ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 64);
+    let lhs = x.add(&bv_u(0, 64));
+    prove_rule("add_zero_identity_i64", &lhs, &x, "∀x: i64. x + 0 = x ✓")
 }
 
 /// Verify: x * (2^n) == x << n for i64
 #[cfg(feature = "verification")]
 pub fn verify_strength_reduction_mul_power2_i64(power: u32) -> RuleProof {
-    let start = std::time::Instant::now();
     let rule_name = format!("strength_reduction_mul_pow2_i64({})", 1u64 << power);
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 64);
-
-    let multiplier = BV::from_u64(1u64 << power, 64);
-    let mul_result = x.bvmul(&multiplier);
-
-    let shift_amt = BV::from_u64(power as u64, 64);
-    let shift_result = x.bvshl(&shift_amt);
-
-    solver.assert(&mul_result.eq(&shift_result).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(
-            &rule_name,
-            time_ms,
-            &format!("∀x: i64. x * {} = x << {} ✓", 1u64 << power, power),
-        ),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(&rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(&rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 64);
+    let lhs = x.mul(&bv_u(1u64 << power, 64));
+    let rhs = x.shl(&bv_u(power as u64, 64));
+    prove_rule(
+        &rule_name,
+        &lhs,
+        &rhs,
+        &format!("∀x: i64. x * {} = x << {} ✓", 1u64 << power, power),
+    )
 }
 
 // ============================================================================
@@ -805,51 +473,26 @@ pub fn verify_strength_reduction_mul_power2_i64(power: u32) -> RuleProof {
 /// This is a NEGATIVE proof - showing when an optimization is INVALID
 #[cfg(feature = "verification")]
 pub fn verify_shift_left_right_not_identity_i32(n: u32) -> RuleProof {
-    let start = std::time::Instant::now();
     let rule_name = format!("shift_left_right_NOT_identity_i32({})", n);
 
     if n == 0 || n >= 32 {
         return RuleProof::error(&rule_name, "shift amount must be 1-31", 0);
     }
 
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let shift_amt = BV::from_u64(n as u64, 32);
-
+    let x = RuleTerm::new_const("x", 32);
+    let shift_amt = bv_u(n as u64, 32);
     // (x << n) >> n
-    let shifted = x.bvshl(&shift_amt).bvlshr(&shift_amt);
+    let shifted = x.shl(&shift_amt).lshr(&shift_amt);
 
-    // Try to find x where (x << n) >> n != x
-    solver.assert(&shifted.eq(&x).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Sat => {
-            // Found counterexample - this proves the optimization is INVALID
-            let model = solver.get_model().unwrap();
-            RuleProof::proven(
-                &rule_name,
-                time_ms,
-                &format!(
-                    "∃x: i32. (x << {}) >> {} ≠ x (found counterexample: {}) ✓",
-                    n, n, model
-                ),
-            )
-        }
-        SatResult::Unsat => {
-            // No counterexample - this would be unexpected
-            RuleProof::disproven(
-                &rule_name,
-                "unexpectedly no counterexample found".to_string(),
-                time_ms,
-            )
-        }
-        SatResult::Unknown => RuleProof::error(&rule_name, "solver returned unknown", time_ms),
-    }
+    // NEGATIVE proof: (x << n) >> n == x must NOT hold for all x. A
+    // counterexample from the solver is exactly what proves the optimization
+    // is invalid.
+    prove_rule_not_equiv(
+        &rule_name,
+        &shifted,
+        &x,
+        &format!("∃x: i32. (x << {}) >> {} ≠ x", n, n),
+    )
 }
 
 // ============================================================================
@@ -1138,170 +781,68 @@ pub fn verify_pipeline_composition() -> Vec<RuleProof> {
 /// Verify: if (const 1) then A else B → A (dead else branch)
 #[cfg(feature = "verification")]
 pub fn verify_constant_if_true_elimination() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "constant_if_true_elimination";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    // Model: if (1) then x else y
-    // After optimization: x
-    //
-    // For any x, y: if(1, x, y) = x
-    let x = BV::new_const("x", 32);
-    let y = BV::new_const("y", 32);
-    let one = BV::from_u64(1, 32);
-    let zero = BV::from_u64(0, 32);
-
+    // Model: if (1) then x else y  → x. For any x, y: if(1, x, y) = x
+    let x = RuleTerm::new_const("x", 32);
+    let y = RuleTerm::new_const("y", 32);
+    let one = bv_u(1, 32);
+    let zero = bv_u(0, 32);
     // if (1 != 0) then x else y
-    let if_result = one.eq(&zero).not().ite(&x, &y);
-
-    // Should equal x
-    solver.assert(&if_result.eq(&x).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(
-            rule_name,
-            time_ms,
-            "∀x,y. if(1, x, y) = x (dead else elimination) ✓",
-        ),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let lhs = one.eq_bool(&zero).not().ite(&x, &y);
+    prove_rule(
+        "constant_if_true_elimination",
+        &lhs,
+        &x,
+        "∀x,y. if(1, x, y) = x (dead else elimination) ✓",
+    )
 }
 
 /// Verify: if (const 0) then A else B → B (dead then branch)
 #[cfg(feature = "verification")]
 pub fn verify_constant_if_false_elimination() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "constant_if_false_elimination";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let y = BV::new_const("y", 32);
-    let zero = BV::from_u64(0, 32);
-
+    let x = RuleTerm::new_const("x", 32);
+    let y = RuleTerm::new_const("y", 32);
+    let zero = bv_u(0, 32);
     // if (0 != 0) then x else y = y
-    let if_result = zero.eq(&zero).not().ite(&x, &y);
-
-    solver.assert(&if_result.eq(&y).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(
-            rule_name,
-            time_ms,
-            "∀x,y. if(0, x, y) = y (dead then elimination) ✓",
-        ),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let lhs = zero.eq_bool(&zero).not().ite(&x, &y);
+    prove_rule(
+        "constant_if_false_elimination",
+        &lhs,
+        &y,
+        "∀x,y. if(0, x, y) = y (dead then elimination) ✓",
+    )
 }
 
 /// Verify: select(1, x, y) → x
 #[cfg(feature = "verification")]
 pub fn verify_select_true() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "select_true";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let y = BV::new_const("y", 32);
-    let one = BV::from_u64(1, 32);
-    let zero = BV::from_u64(0, 32);
-
+    let x = RuleTerm::new_const("x", 32);
+    let y = RuleTerm::new_const("y", 32);
+    let one = bv_u(1, 32);
+    let zero = bv_u(0, 32);
     // select(cond, x, y) = if cond != 0 then x else y
-    let select_result = one.eq(&zero).not().ite(&x, &y);
-
-    solver.assert(&select_result.eq(&x).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x,y. select(1, x, y) = x ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let lhs = one.eq_bool(&zero).not().ite(&x, &y);
+    prove_rule("select_true", &lhs, &x, "∀x,y. select(1, x, y) = x ✓")
 }
 
 /// Verify: select(0, x, y) → y
 #[cfg(feature = "verification")]
 pub fn verify_select_false() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "select_false";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let x = BV::new_const("x", 32);
-    let y = BV::new_const("y", 32);
-    let zero = BV::from_u64(0, 32);
-
-    let select_result = zero.eq(&zero).not().ite(&x, &y);
-
-    solver.assert(&select_result.eq(&y).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀x,y. select(0, x, y) = y ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let x = RuleTerm::new_const("x", 32);
+    let y = RuleTerm::new_const("y", 32);
+    let zero = bv_u(0, 32);
+    let lhs = zero.eq_bool(&zero).not().ite(&x, &y);
+    prove_rule("select_false", &lhs, &y, "∀x,y. select(0, x, y) = y ✓")
 }
 
 /// Verify: select(c, x, x) → x (both branches same)
 #[cfg(feature = "verification")]
 pub fn verify_select_same() -> RuleProof {
-    let start = std::time::Instant::now();
-    let rule_name = "select_same";
-
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
-    let solver = Solver::new();
-
-    let c = BV::new_const("c", 32);
-    let x = BV::new_const("x", 32);
-    let zero = BV::from_u64(0, 32);
-
+    let c = RuleTerm::new_const("c", 32);
+    let x = RuleTerm::new_const("x", 32);
+    let zero = bv_u(0, 32);
     // select(c, x, x) should always equal x regardless of c
-    let select_result = c.eq(&zero).not().ite(&x, &x);
-
-    solver.assert(&select_result.eq(&x).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => RuleProof::proven(rule_name, time_ms, "∀c,x. select(c, x, x) = x ✓"),
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let lhs = c.eq_bool(&zero).not().ite(&x, &x);
+    prove_rule("select_same", &lhs, &x, "∀c,x. select(c, x, x) = x ✓")
 }
 
 /// Verify all control flow optimizations
@@ -1426,11 +967,17 @@ fn generate_wat_for_rule(rule_name: &str, inputs: &[(String, i64)]) -> String {
     }
 }
 
-/// Probe for edge cases by asking Z3 to find inputs that produce specific outputs
+/// Probe for edge cases by asking Z3 to find inputs that produce specific outputs.
+///
+/// NOTE: this is a *satisfiability* probe (find some `x` meeting a constraint),
+/// not a rule-equivalence proof, so it sits OUTSIDE the `RuleSolver` migration
+/// boundary and stays on Z3 directly (issue #277). ordeal's `prove_equiv` API is
+/// specifically for the all-inputs equivalence obligation the rules use.
 #[cfg(feature = "verification")]
 pub fn find_edge_case_inputs(target_output: i32, operation: &str) -> Option<GeneratedTestCase> {
-    // Default config used via thread-local context
-    // Context is thread-local in z3 0.19
+    use z3::ast::BV;
+    use z3::{SatResult, Solver};
+
     let solver = Solver::new();
 
     let x = BV::new_const("x", 32);
@@ -1785,23 +1332,27 @@ pub fn generate_isle_proof_obligations(rules: &[IsleRule]) -> Vec<RuleProof> {
 /// then the ISLE rule is proven correct for all 2^N * 2^N input combinations.
 #[cfg(feature = "verification")]
 fn verify_isle_constant_fold_rule(operation: &str, rule_name: &str, bit_width: u32) -> RuleProof {
-    let start = std::time::Instant::now();
-
-    let solver = Solver::new();
-
     // Create symbolic constants at the native bit width
-    let a = BV::new_const("a", bit_width);
-    let b = BV::new_const("b", bit_width);
+    let a = RuleTerm::new_const("a", bit_width);
+    let b = RuleTerm::new_const("b", bit_width);
+
+    // Helper: apply a binary operation to two operands in the rule DSL.
+    let apply = |op: &str, x: &RuleTerm, y: &RuleTerm| -> Option<RuleTerm> {
+        Some(match op {
+            "iadd32" | "iadd64" => x.add(y),
+            "isub32" | "isub64" => x.sub(y),
+            "imul32" | "imul64" => x.mul(y),
+            "iand32" | "iand64" => x.and(y),
+            "ior32" | "ior64" => x.or(y),
+            "ixor32" | "ixor64" => x.xor(y),
+            _ => return None,
+        })
+    };
 
     // LHS: the WebAssembly runtime operation (direct bitvector arithmetic)
-    let wasm_result = match operation {
-        "iadd32" | "iadd64" => a.bvadd(&b),
-        "isub32" | "isub64" => a.bvsub(&b),
-        "imul32" | "imul64" => a.bvmul(&b),
-        "iand32" | "iand64" => a.bvand(&b),
-        "ior32" | "ior64" => a.bvor(&b),
-        "ixor32" | "ixor64" => a.bvxor(&b),
-        _ => {
+    let wasm_result = match apply(operation, &a, &b) {
+        Some(t) => t,
+        None => {
             return RuleProof::error(
                 rule_name,
                 &format!("Unsupported operation: {}", operation),
@@ -1820,53 +1371,29 @@ fn verify_isle_constant_fold_rule(operation: &str, rule_name: &str, bit_width: u
     // (which are defined as modular arithmetic on N-bit values).
     let a_wide = a.sign_ext(bit_width); // sign-extend to 2*N bits
     let b_wide = b.sign_ext(bit_width);
-
-    let wide_result = match operation {
-        "iadd32" | "iadd64" => a_wide.bvadd(&b_wide),
-        "isub32" | "isub64" => a_wide.bvsub(&b_wide),
-        "imul32" | "imul64" => a_wide.bvmul(&b_wide),
-        "iand32" | "iand64" => a_wide.bvand(&b_wide),
-        "ior32" | "ior64" => a_wide.bvor(&b_wide),
-        "ixor32" | "ixor64" => a_wide.bvxor(&b_wide),
-        _ => unreachable!(),
-    };
-
+    let wide_result = apply(operation, &a_wide, &b_wide).expect("operation validated above");
     // Truncate back to N bits (extract bits [N-1:0])
     let rust_helper_result = wide_result.extract(bit_width - 1, 0);
 
-    // Proof obligation: wasm_result != rust_helper_result
-    // If UNSAT, then they are equal for ALL inputs -> rule is correct
-    solver.assert(&wasm_result.eq(&rust_helper_result).not());
-
-    let time_ms = start.elapsed().as_millis() as u64;
-
-    match solver.check() {
-        SatResult::Unsat => {
-            let op_symbol = match operation {
-                "iadd32" | "iadd64" => "+",
-                "isub32" | "isub64" => "-",
-                "imul32" | "imul64" => "*",
-                "iand32" | "iand64" => "&",
-                "ior32" | "ior64" => "|",
-                "ixor32" | "ixor64" => "^",
-                _ => "?",
-            };
-            let ty = if bit_width == 64 { "i64" } else { "i32" };
-            RuleProof::proven(
-                rule_name,
-                time_ms,
-                &format!(
-                    "ISLE constant fold {}: ∀a,b: {}. wasm_{}(a, b) = rust_wrapping_{}(a, b) ✓",
-                    operation, ty, op_symbol, op_symbol
-                ),
-            )
-        }
-        SatResult::Sat => {
-            let model = solver.get_model().unwrap();
-            RuleProof::disproven(rule_name, format!("{}", model), time_ms)
-        }
-        SatResult::Unknown => RuleProof::error(rule_name, "solver returned unknown", time_ms),
-    }
+    let op_symbol = match operation {
+        "iadd32" | "iadd64" => "+",
+        "isub32" | "isub64" => "-",
+        "imul32" | "imul64" => "*",
+        "iand32" | "iand64" => "&",
+        "ior32" | "ior64" => "|",
+        "ixor32" | "ixor64" => "^",
+        _ => "?",
+    };
+    let ty = if bit_width == 64 { "i64" } else { "i32" };
+    prove_rule(
+        rule_name,
+        &wasm_result,
+        &rust_helper_result,
+        &format!(
+            "ISLE constant fold {}: ∀a,b: {}. wasm_{}(a, b) = rust_wrapping_{}(a, b) ✓",
+            operation, ty, op_symbol, op_symbol
+        ),
+    )
 }
 
 // ============================================================================


### PR DESCRIPTION
Refs #277 (Tier-1 of the Z3→ordeal migration). Moves loom's algebraic-RULE verifier onto ordeal, with Z3 kept as a differential oracle. The migration boundary + the de-risking receipt.

## What
- New `loom-core/src/rule_solver.rs` — the migration seam: a backend-neutral `RuleTerm`/`RuleBool` QF_BV DSL + `trait RuleSolver { prove_rule_equiv -> {Proven, Disproven(cex), Unknown} }`, with **`Z3RuleSolver`** (original logic), **`OrdealRuleSolver`** (`ordeal::Solver::prove_equiv` + `cert.recheck()` LRAT re-validation), and **`DifferentialRuleSolver`** (runs both, panics on disagreement). Selected via `LOOM_VERIFY_BACKEND={z3,ordeal,both}`, default `z3`. `verify.rs` untouched (that's Tier-2); a comment notes it will grow the same seam.

## The receipt
- **57/57 rules verified; 57/57 agree** under z3-only, ordeal-only, and both.
- **Full loom-core suite (462 tests) green under `LOOM_VERIFY_BACKEND=both`** — the `DifferentialRuleSolver` would panic on any mismatch; it didn't. **No ordeal gaps surfaced.**
- ordeal additionally `recheck()`s every UNSAT certificate — an independently re-checkable proof Z3 never offered.

## Note
`find_edge_case_inputs` stays on Z3 by design — it's a *satisfiability probe* (find some x), not an all-inputs equivalence, so it's outside the `prove_equiv` boundary (documented, Z3 import scoped locally).

This is the first real slice of removing Z3 from loom, and it proves ordeal matches Z3 on the QF_BV fragment — de-risking Tier-2 (`verify.rs`). Targets v1.3. 🤖 Generated with [Claude Code](https://claude.com/claude-code)